### PR TITLE
add set owner and mode for copy-blossom

### DIFF
--- a/src/processing/blossoms/files/common_files/path_copy_blossom.h
+++ b/src/processing/blossoms/files/common_files/path_copy_blossom.h
@@ -47,6 +47,8 @@ private:
 
     std::string m_sourcePath = "";
     std::string m_destinationPath = "";
+    std::string m_mode = "";
+    std::string m_owner = "";
 };
 
 }


### PR DESCRIPTION
## Description

- add set owner and mode for copy-blossom

## How it was tested?

- simple example test:

```
path("test-copy")
-> copy:
    - source_path = "/tmp/test"
    - dest_path = "/tmp/test2"
    - mode = 666
```

and

```
path("test-copy")
-> copy:
    - source_path = "/tmp/test"
    - dest_path = "/tmp/test2"
    - owner = "root"
```