### PR TITLE
Add init file processing for directories

### DIFF
--- a/src/converter/converter.cpp
+++ b/src/converter/converter.cpp
@@ -379,21 +379,6 @@ Converter::convertSubtree(const JsonItem &subtree,
     const JsonItem items = subtree.get("items-input");
     convertItemValues(subtreeItem, items, success);
 
-    // convert all blossoms of the group
-    const JsonItem subTypeArray = subtree.get("blossoms");
-    for(uint32_t i = 0; i < subTypeArray.size(); i++)
-    {
-        const JsonItem item = subTypeArray.get(i);
-        BlossomItem* blossomItem = new BlossomItem();
-
-        convertItemValues(blossomItem, item.get("items-input"), success);
-        const std::string subtype = item.get("blossom-type").toString();
-        subtreeItem->internalSubtrees.insert(
-                    std::pair<std::string, ValueItemMap>(subtype, blossomItem->values));
-
-        delete blossomItem;
-    }
-
     return subtreeItem;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,10 +132,12 @@ int main(int argc, char *argv[])
     std::cout << "input-path: " << inputPath << std::endl;
 
     if(Kitsunemimi::Persistence::isDir(inputPath)
-            && argParser.wasSet("init-tree-id") == false)
+            && argParser.wasSet("init-tree-id") == false
+            && Kitsunemimi::Persistence::isFile(inputPath + "/root.tree") == false)
     {
-        std::cout<<"because the input-path is a directory"
-                   ", init-tree-id must be set as well."<<std::endl;
+        LOG_ERROR("Because the input-path is a directory"
+                   ", init-tree-id have to be set as well or "
+                   "the directory have to contain a 'root.tree'-file.");
     }
 
     if(argParser.wasSet("server-address")

--- a/src/processing/sakura_thread.cpp
+++ b/src/processing/sakura_thread.cpp
@@ -336,7 +336,7 @@ SakuraThread::processSubtree(SubtreeItem* subtreeItem)
     bool fillResult = false;
 
     TreeHandler* treeHandler = SakuraRoot::m_root->m_treeHandler;
-    SakuraItem* newSubtree = treeHandler->getConvertedTree(subtreeItem->nameOrPath);
+    SakuraItem* newSubtree = treeHandler->getConvertedTree(subtreeItem->nameOrPath, "");
 
     // fill normal map
     fillResult = fillInputValueItemMap(subtreeItem->values, m_parentValues, errorMessage);

--- a/src/processing/sakura_thread.cpp
+++ b/src/processing/sakura_thread.cpp
@@ -338,6 +338,13 @@ SakuraThread::processSubtree(SubtreeItem* subtreeItem)
     TreeHandler* treeHandler = SakuraRoot::m_root->m_treeHandler;
     SakuraItem* newSubtree = treeHandler->getConvertedTree(subtreeItem->nameOrPath, "");
 
+    if(newSubtree == nullptr)
+    {
+        SakuraRoot::m_root->createError("subtree-processing",
+                                        "subtree doesn't exist: " + subtreeItem->nameOrPath);
+        return false;
+    }
+
     // fill normal map
     fillResult = fillInputValueItemMap(subtreeItem->values, m_parentValues, errorMessage);
     if(fillResult == false)

--- a/src/sakura_root.cpp
+++ b/src/sakura_root.cpp
@@ -174,7 +174,9 @@ SakuraRoot::startProcess(const std::string &inputPath,
     if(tree == nullptr) {
         return false;
     }
-    if(runProcess(tree, initialValues) == false) {
+    if(runProcess(tree, initialValues) == false)
+    {
+        LOG_ERROR(m_errorOutput.toString());
         return false;
     }
 

--- a/src/sakura_root.cpp
+++ b/src/sakura_root.cpp
@@ -170,7 +170,7 @@ SakuraRoot::startProcess(const std::string &inputPath,
 
     shareAllTrees();
 
-    SakuraItem* tree = m_treeHandler->getConvertedTree(initialTreeId);
+    SakuraItem* tree = m_treeHandler->getConvertedTree(initialTreeId, inputPath);
     if(tree == nullptr) {
         return false;
     }
@@ -198,7 +198,7 @@ SakuraRoot::startSubtreeProcess(const std::string &treeId,
     std::cout<<"startSubtreeProcess"<<std::endl;
 
     // get tree
-    SakuraItem* processPlan = m_treeHandler->getConvertedTree(treeId);
+    SakuraItem* processPlan = m_treeHandler->getConvertedTree(treeId, "");
     if(processPlan == nullptr) {
         return false;
     }

--- a/src/tree_handler.cpp
+++ b/src/tree_handler.cpp
@@ -184,6 +184,8 @@ TreeHandler::getConvertedTreeFromMap(const std::string &treeId)
     if(it != m_predefinedTrees.end()) {
         return it->second.convertedItem;
     }
+
+    return nullptr;
 }
 
 /**

--- a/src/tree_handler.h
+++ b/src/tree_handler.h
@@ -32,7 +32,8 @@ public:
     bool addTree(const std::string &treeId,
                  const std::string &content);
 
-    SakuraItem* getConvertedTree(const std::string &treeId);
+    SakuraItem* getConvertedTree(const std::string &treeId,
+                                 const std::string &initPath);
     const JsonItem getParsedTree(const std::string &treeId);
 
     bool loadPredefinedSubtrees();
@@ -43,6 +44,8 @@ public:
 private:
     Converter* m_converter = nullptr;
     Kitsunemimi::Sakura::SakuraParsing* m_parser = nullptr;
+
+    SakuraItem* getConvertedTreeFromMap(const std::string &treeId);
 };
 
 }


### PR DESCRIPTION
## Description

- Add init file processing for directories named `root.tree`
- Fixed subtrees in case, that the id doesn't exist

## Related Issues

- #145 

## How it was tested?

- renamed example to `root.tree` and checked without `--init-tree-id`-flag
