### PR TITLE
fix override of uninit values

### DIFF
--- a/src/processing/blossoms/blossom.cpp
+++ b/src/processing/blossoms/blossom.cpp
@@ -38,20 +38,6 @@ Blossom::~Blossom() {}
 void
 Blossom::growBlossom(BlossomItem &blossomItem)
 {
-    const std::vector<std::string> uninitItems = checkItems(blossomItem.values);
-
-    if(uninitItems.size() > 0)
-    {
-        std::string output = "The following items are not initialized: \n";
-        for(uint32_t i = 0; i < uninitItems.size(); i++)
-        {
-            output += uninitItems.at(i) + "\n";
-        }
-        blossomItem.outputMessage = output;
-        blossomItem.success = false;
-        return;
-    }
-
     //-------------------------------
     LOG_DEBUG("initBlossom " + blossomItem.blossomName);
 

--- a/src/processing/common/item_methods.cpp
+++ b/src/processing/common/item_methods.cpp
@@ -462,16 +462,16 @@ overrideItems(ValueItemMap &original,
  * @return list of not initialized values
  */
 const std::vector<std::string>
-checkItems(ValueItemMap &items)
+checkItems(DataMap &items)
 {
     std::vector<std::string> result;
 
-    std::map<std::string, ValueItem>::const_iterator it;
-    for(it = items.const_begin();
-        it != items.const_end();
+    std::map<std::string, DataItem*>::const_iterator it;
+    for(it = items.m_map.begin();
+        it != items.m_map.end();
         it++)
     {
-        if(it->second.item->getString() == "{{}}") {
+        if(it->second->getString() == "{{}}") {
             result.push_back(it->first);
         }
     }

--- a/src/processing/common/item_methods.h
+++ b/src/processing/common/item_methods.h
@@ -65,7 +65,7 @@ void overrideItems(DataMap &original,
 void overrideItems(ValueItemMap &original,
                    const ValueItemMap &override,
                    bool onlyExisting);
-const std::vector<std::string> checkItems(ValueItemMap &items);
+const std::vector<std::string> checkItems(DataMap &items);
 const std::string convertBlossomOutput(const BlossomItem &blossom);
 
 }

--- a/src/processing/sakura_thread.cpp
+++ b/src/processing/sakura_thread.cpp
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @file        sakura_thread.cpp
  *
  * @author      Tobias Anker <tobias.anker@kitsunemimi.moe>
@@ -297,7 +297,7 @@ SakuraThread::processTree(TreeItem* treeItem)
 {
     LOG_DEBUG("processTree");
 
-    const std::vector<std::string> uninitItems = checkItems(treeItem->values);
+    const std::vector<std::string> uninitItems = checkItems(m_parentValues);
     if(uninitItems.size() > 0)
     {
         std::string message = "The following items are not initialized: \n";

--- a/tests/processing/common/item_methods_test.cpp
+++ b/tests/processing/common/item_methods_test.cpp
@@ -98,7 +98,7 @@ ItemMethods_Test::overrideItems_test()
 void
 ItemMethods_Test::checkItems_test()
 {
-    ValueItemMap items;
+    DataMap items;
     items.insert("x", new DataValue("{{}}"));
     items.insert("y", new DataValue("asdf"));
 


### PR DESCRIPTION
## Description

- fix override of uninit values

## How it was tested?

used following example:

```
["install_branch"]
- test2 = "test"
- test = "{{}}"

print("test-print")
- test = test
- test2 = test2
```

Tested with and without overriding `test`.