### PR TITLE
Update template blossom

### DIFF
--- a/SakuraTree.pro
+++ b/SakuraTree.pro
@@ -111,7 +111,8 @@ HEADERS += \
     src/args.h \
     src/config.h \
     src/processing/blossoms/files/template_files/template_create_file_blossom.h \
-    src/processing/blossoms/files/template_files/template_create_string_blossom.h
+    src/processing/blossoms/files/template_files/template_create_string_blossom.h \
+    src/processing/blossoms/files/template_files/template_methods.h
 
 SOURCES += \
     src/processing/blossoms/files/ini_files/ini_delete_entry_blossom.cpp \
@@ -150,7 +151,8 @@ SOURCES += \
     src/processing/blossoms/files/common_files/path_rename_blossom.cpp \
     src/processing/blossoms/special/item_update_blossom.cpp \
     src/processing/blossoms/files/template_files/template_create_file_blossom.cpp \
-    src/processing/blossoms/files/template_files/template_create_string_blossom.cpp
+    src/processing/blossoms/files/template_files/template_create_string_blossom.cpp \
+    src/processing/blossoms/files/template_files/template_methods.cpp
 
 CONFIG(run_tests) {
 TARGET = SakuraTree_Test

--- a/SakuraTree.pro
+++ b/SakuraTree.pro
@@ -74,7 +74,6 @@ HEADERS += \
     src/processing/blossoms/files/ini_files/ini_delete_entry_blossom.h \
     src/processing/blossoms/files/ini_files/ini_read_entry_blossom.h \
     src/processing/blossoms/files/ini_files/ini_set_entry_blossom.h \
-    src/processing/blossoms/files/template_files/template_create_blossom.h \
     src/processing/blossoms/files/text_files/text_append_blossom.h \
     src/processing/blossoms/files/text_files/text_read_blossom.h \
     src/processing/blossoms/files/text_files/text_replace_blossom.h \
@@ -110,13 +109,14 @@ HEADERS += \
     src/processing/blossoms/files/common_files/path_rename_blossom.h \
     src/processing/blossoms/special/item_update_blossom.h \
     src/args.h \
-    src/config.h
+    src/config.h \
+    src/processing/blossoms/files/template_files/template_create_file_blossom.h \
+    src/processing/blossoms/files/template_files/template_create_string_blossom.h
 
 SOURCES += \
     src/processing/blossoms/files/ini_files/ini_delete_entry_blossom.cpp \
     src/processing/blossoms/files/ini_files/ini_read_entry_blossom.cpp \
     src/processing/blossoms/files/ini_files/ini_set_entry_blossom.cpp \
-    src/processing/blossoms/files/template_files/template_create_blossom.cpp \
     src/processing/blossoms/files/text_files/text_append_blossom.cpp \
     src/processing/blossoms/files/text_files/text_read_blossom.cpp \
     src/processing/blossoms/files/text_files/text_replace_blossom.cpp \
@@ -148,7 +148,9 @@ SOURCES += \
     src/processing/blossoms/files/common_files/path_copy_blossom.cpp \
     src/processing/blossoms/files/common_files/path_delete_blossom.cpp \
     src/processing/blossoms/files/common_files/path_rename_blossom.cpp \
-    src/processing/blossoms/special/item_update_blossom.cpp
+    src/processing/blossoms/special/item_update_blossom.cpp \
+    src/processing/blossoms/files/template_files/template_create_file_blossom.cpp \
+    src/processing/blossoms/files/template_files/template_create_string_blossom.cpp
 
 CONFIG(run_tests) {
 TARGET = SakuraTree_Test

--- a/build.sh
+++ b/build.sh
@@ -81,7 +81,7 @@ get_required_kitsune_lib_repo "libKitsunemimiJinja2" "master" 1
 echo ""
 echo "###########################################################################################################"
 echo ""
-get_required_kitsune_lib_repo "libKitsunemimiSakuraParser" "update-template-blossom" 1
+get_required_kitsune_lib_repo "libKitsunemimiSakuraParser" "master" 1
 echo ""
 echo "###########################################################################################################"
 echo ""

--- a/build.sh
+++ b/build.sh
@@ -81,7 +81,7 @@ get_required_kitsune_lib_repo "libKitsunemimiJinja2" "master" 1
 echo ""
 echo "###########################################################################################################"
 echo ""
-get_required_kitsune_lib_repo "libKitsunemimiSakuraParser" "master" 1
+get_required_kitsune_lib_repo "libKitsunemimiSakuraParser" "update-template-blossom" 1
 echo ""
 echo "###########################################################################################################"
 echo ""

--- a/examples/example.seed
+++ b/examples/example.seed
@@ -1,9 +1,0 @@
-["test-remote installation"]
-
-sakura:
-- tags = ["test-node"]
-- ip_address = "192.168.56.101"
-- ssh_user = "sakura"
-- ssh_port = 22
-- ssh_key_path = "~/.ssh/sakura_test"
-- target_path = "/tmp/"

--- a/src/converter/common_converter_methods.cpp
+++ b/src/converter/common_converter_methods.cpp
@@ -72,8 +72,8 @@ checkOutput(BlossomItem &blossomItem,
             const bool hasOutput)
 {
     std::map<std::string, ValueItem>::const_iterator it;
-    for(it = blossomItem.values.const_begin();
-        it != blossomItem.values.const_end();
+    for(it = blossomItem.values.m_valueMap.begin();
+        it != blossomItem.values.m_valueMap.end();
         it++)
     {
         ValueItem tempItem = blossomItem.values.getValueItem(it->first);
@@ -116,8 +116,8 @@ checkBlossomItem(BlossomItem &blossomItem,
     {
         // check if all keys in the values of the blossom-item also exist in the required-key-list
         std::map<std::string, ValueItem>::const_iterator it;
-        for(it = blossomItem.values.const_begin();
-            it != blossomItem.values.const_end();
+        for(it = blossomItem.values.m_valueMap.begin();
+            it != blossomItem.values.m_valueMap.end();
             it++)
         {
             ValueItem tempItem = blossomItem.values.getValueItem(it->first);

--- a/src/processing/blossoms/blossom_getter.cpp
+++ b/src/processing/blossoms/blossom_getter.cpp
@@ -45,7 +45,7 @@
 #include <processing/blossoms/files/common_files/path_chmod_blossom.h>
 #include <processing/blossoms/files/common_files/path_chown_blossom.h>
 
-#include <processing/blossoms/files/template_files/template_create_blossom.h>
+#include <processing/blossoms/files/template_files/template_create_file_blossom.h>
 
 #include <processing/blossoms/files/text_files/text_append_blossom.h>
 #include <processing/blossoms/files/text_files/text_read_blossom.h>
@@ -122,7 +122,7 @@ getBlossom(const std::string blossomGroupType,
     if(blossomGroupType == "template")
     {
         if(blossomType == "create") {
-            return new TemplateCreateBlossom();
+            return new TemplateCreateFileBlossom();
         }
     }
 

--- a/src/processing/blossoms/blossom_getter.cpp
+++ b/src/processing/blossoms/blossom_getter.cpp
@@ -46,6 +46,7 @@
 #include <processing/blossoms/files/common_files/path_chown_blossom.h>
 
 #include <processing/blossoms/files/template_files/template_create_file_blossom.h>
+#include <processing/blossoms/files/template_files/template_create_string_blossom.h>
 
 #include <processing/blossoms/files/text_files/text_append_blossom.h>
 #include <processing/blossoms/files/text_files/text_read_blossom.h>
@@ -121,8 +122,12 @@ getBlossom(const std::string blossomGroupType,
 
     if(blossomGroupType == "template")
     {
-        if(blossomType == "create") {
+        if(blossomType == "create_file") {
             return new TemplateCreateFileBlossom();
+        }
+
+        if(blossomType == "create_string") {
+            return new TemplateCreateStringBlossom();
         }
     }
 

--- a/src/processing/blossoms/files/template_files/template_create_file_blossom.cpp
+++ b/src/processing/blossoms/files/template_files/template_create_file_blossom.cpp
@@ -1,5 +1,5 @@
 /**
- * @file        template_create_blossom.cpp
+ * @file        template_create_file_blossom.cpp
  *
  * @author      Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
@@ -20,7 +20,7 @@
  *      limitations under the License.
  */
 
-#include "template_create_blossom.h"
+#include "template_create_file_blossom.h"
 #include <libKitsunemimiPersistence/files/file_methods.h>
 #include <sakura_root.h>
 #include <libKitsunemimiJinja2/jinja2_converter.h>
@@ -29,7 +29,7 @@
 namespace SakuraTree
 {
 
-TemplateCreateBlossom::TemplateCreateBlossom()
+TemplateCreateFileBlossom::TemplateCreateFileBlossom()
     : Blossom()
 {
     m_requiredKeys.insert("source_path", new DataValue(true));
@@ -41,7 +41,7 @@ TemplateCreateBlossom::TemplateCreateBlossom()
  * initBlossom
  */
 void
-TemplateCreateBlossom::initBlossom(BlossomItem &blossomItem)
+TemplateCreateFileBlossom::initBlossom(BlossomItem &blossomItem)
 {
     m_templatePath = blossomItem.values.getValueAsString("source_path");
     m_destinationPath = blossomItem.values.getValueAsString("dest_path");
@@ -58,7 +58,7 @@ TemplateCreateBlossom::initBlossom(BlossomItem &blossomItem)
  * preCheck
  */
 void
-TemplateCreateBlossom::preCheck(BlossomItem &blossomItem)
+TemplateCreateFileBlossom::preCheck(BlossomItem &blossomItem)
 {
     // read template-file
     std::string fileContent = SakuraRoot::m_currentGarden->getTemplate(m_templatePath);
@@ -121,7 +121,7 @@ TemplateCreateBlossom::preCheck(BlossomItem &blossomItem)
  * runTask
  */
 void
-TemplateCreateBlossom::runTask(BlossomItem &blossomItem)
+TemplateCreateFileBlossom::runTask(BlossomItem &blossomItem)
 {
     std::string errorMessage = "";
     bool writeResult = Kitsunemimi::Persistence::writeFile(m_destinationPath,
@@ -145,7 +145,7 @@ TemplateCreateBlossom::runTask(BlossomItem &blossomItem)
  * postCheck
  */
 void
-TemplateCreateBlossom::postCheck(BlossomItem &blossomItem)
+TemplateCreateFileBlossom::postCheck(BlossomItem &blossomItem)
 {
     std::string errorMessage = "";
     std::string fileContent = "";
@@ -164,7 +164,7 @@ TemplateCreateBlossom::postCheck(BlossomItem &blossomItem)
  * closeBlossom
  */
 void
-TemplateCreateBlossom::closeBlossom(BlossomItem &blossomItem)
+TemplateCreateFileBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
 }

--- a/src/processing/blossoms/files/template_files/template_create_file_blossom.cpp
+++ b/src/processing/blossoms/files/template_files/template_create_file_blossom.cpp
@@ -164,11 +164,10 @@ TemplateCreateFileBlossom::runTask(BlossomItem &blossomItem)
 void
 TemplateCreateFileBlossom::postCheck(BlossomItem &blossomItem)
 {
-    std::string errorMessage = "";
     std::string fileContent = "";
     bool ret = Kitsunemimi::Persistence::readFile(fileContent,
                                                   m_destinationPath,
-                                                  errorMessage);
+                                                  blossomItem.outputMessage);
     if(ret == false
             || m_convertedContent != fileContent)
     {

--- a/src/processing/blossoms/files/template_files/template_create_file_blossom.cpp
+++ b/src/processing/blossoms/files/template_files/template_create_file_blossom.cpp
@@ -50,8 +50,8 @@ TemplateCreateFileBlossom::initBlossom(BlossomItem &blossomItem)
 
     // create source-path
     m_templatePath = SakuraRoot::m_currentGarden->getRelativePath(blossomItem.blossomPath,
-                                                                m_templatePath,
-                                                                "templates");
+                                                                  m_templatePath,
+                                                                  "templates");
 
     blossomItem.success = true;
 }

--- a/src/processing/blossoms/files/template_files/template_create_file_blossom.h
+++ b/src/processing/blossoms/files/template_files/template_create_file_blossom.h
@@ -48,6 +48,8 @@ private:
 
     std::string m_templatePath = "";
     std::string m_destinationPath = "";
+    std::string m_owner = "";
+    std::string m_permission = "";
 
     std::string m_convertedContent = "";
 };

--- a/src/processing/blossoms/files/template_files/template_create_file_blossom.h
+++ b/src/processing/blossoms/files/template_files/template_create_file_blossom.h
@@ -1,0 +1,57 @@
+/**
+ * @file        template_create_file_blossom.h
+ *
+ * @author      Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ * @copyright   Apache License Version 2.0
+ *
+ *      Copyright 2019 Tobias Anker
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+#ifndef TEMPLATE_CREATE_FILE_BLOSSOM_H
+#define TEMPLATE_CREATE_FILE_BLOSSOM_H
+
+#include <processing/blossoms/blossom.h>
+
+namespace SakuraTree
+{
+class TemplateCreateBlossom_Test;
+
+class TemplateCreateFileBlossom
+        : public Blossom
+{
+
+public:
+    TemplateCreateFileBlossom();
+
+protected:
+    void initBlossom(BlossomItem &blossomItem);
+    void preCheck(BlossomItem &blossomItem);
+    void runTask(BlossomItem &blossomItem);
+    void postCheck(BlossomItem &blossomItem);
+    void closeBlossom(BlossomItem &blossomItem);
+
+private:
+    friend TemplateCreateBlossom_Test;
+
+    std::string m_templatePath = "";
+    std::string m_destinationPath = "";
+
+    std::string m_fileContent = "";
+};
+
+}
+
+#endif // TEMPLATE_CREATE_FILE_BLOSSOM_H

--- a/src/processing/blossoms/files/template_files/template_create_string_blossom.cpp
+++ b/src/processing/blossoms/files/template_files/template_create_string_blossom.cpp
@@ -21,9 +21,11 @@
  */
 
 #include "template_create_string_blossom.h"
-#include <libKitsunemimiPersistence/files/file_methods.h>
+#include "template_methods.h"
+
 #include <sakura_root.h>
-#include <libKitsunemimiJinja2/jinja2_converter.h>
+
+#include <libKitsunemimiPersistence/files/file_methods.h>
 #include <libKitsunemimiPersistence/files/text_file.h>
 
 namespace SakuraTree
@@ -60,39 +62,11 @@ TemplateCreateStringBlossom::initBlossom(BlossomItem &blossomItem)
 void
 TemplateCreateStringBlossom::preCheck(BlossomItem &blossomItem)
 {
-    // read template-file
-    std::string fileContent = SakuraRoot::m_currentGarden->getTemplate(m_templatePath);
-    if(fileContent == "")
-    {
-        blossomItem.success = false;
-        blossomItem.outputMessage = "couldn't find template-file " + m_templatePath;
-        return;
-    }
-
-    DataMap inputData;
-    std::map<std::string, ValueItem>::iterator it;
-    for(it = blossomItem.values.begin();
-        it != blossomItem.values.end();
-        it++)
-    {
-        if(it->second.item != nullptr) {
-            inputData.insert(it->first, it->second.item->copy());
-        }
-    }
-
-    // create file-content form template
-    std::string errorMessage;
-    bool jinja2Result = SakuraRoot::m_root->m_jinja2Converter->convert(m_fileContent,
-                                                                       fileContent,
-                                                                       &inputData,
-                                                                       errorMessage);
-    if(jinja2Result == false)
-    {
-        blossomItem.success = false;
-        blossomItem.outputMessage = "couldn't convert template-file "
-                                   + m_templatePath +
-                                   " with reason: "
-                                   + errorMessage;
+    blossomItem.success = convertTemplate(m_convertedContent,
+                                          m_templatePath,
+                                          blossomItem.values,
+                                          blossomItem.outputMessage);
+    if(blossomItem.success == false) {
         return;
     }
 
@@ -100,13 +74,12 @@ TemplateCreateStringBlossom::preCheck(BlossomItem &blossomItem)
     if(Kitsunemimi::Persistence::doesPathExist(m_destinationPath))
     {
         // read the already existing file and compare it the current file-content
-        errorMessage.clear();
-        fileContent.clear();
-        bool results = Kitsunemimi::Persistence::readFile(fileContent,
-                                                          m_destinationPath,
-                                                          errorMessage);
-        if(results == true
-                && m_fileContent == fileContent)
+        std::string existingFileContent;
+        const bool ret = Kitsunemimi::Persistence::readFile(existingFileContent,
+                                                            m_destinationPath,
+                                                            blossomItem.outputMessage);
+        if(ret == true
+                && m_convertedContent == existingFileContent)
         {
             blossomItem.skip = true;
             blossomItem.success = true;
@@ -125,7 +98,7 @@ TemplateCreateStringBlossom::runTask(BlossomItem &blossomItem)
 {
     std::string errorMessage = "";
     bool writeResult = Kitsunemimi::Persistence::writeFile(m_destinationPath,
-                                                           m_fileContent,
+                                                           m_convertedContent,
                                                            errorMessage,
                                                            true);
     if(writeResult == false)
@@ -149,9 +122,11 @@ TemplateCreateStringBlossom::postCheck(BlossomItem &blossomItem)
 {
     std::string errorMessage = "";
     std::string fileContent = "";
-    bool ret = Kitsunemimi::Persistence::readFile(fileContent, m_destinationPath, errorMessage);
+    bool ret = Kitsunemimi::Persistence::readFile(fileContent,
+                                                  m_destinationPath,
+                                                  errorMessage);
     if(ret == false
-            || m_fileContent != fileContent)
+            || m_convertedContent != fileContent)
     {
         blossomItem.success = false;
         return;

--- a/src/processing/blossoms/files/template_files/template_create_string_blossom.cpp
+++ b/src/processing/blossoms/files/template_files/template_create_string_blossom.cpp
@@ -1,0 +1,172 @@
+/**
+ * @file        template_create_string_blossom.cpp
+ *
+ * @author      Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ * @copyright   Apache License Version 2.0
+ *
+ *      Copyright 2019 Tobias Anker
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+#include "template_create_string_blossom.h"
+#include <libKitsunemimiPersistence/files/file_methods.h>
+#include <sakura_root.h>
+#include <libKitsunemimiJinja2/jinja2_converter.h>
+#include <libKitsunemimiPersistence/files/text_file.h>
+
+namespace SakuraTree
+{
+
+TemplateCreateStringBlossom::TemplateCreateStringBlossom()
+    : Blossom()
+{
+    m_requiredKeys.insert("source_path", new DataValue(true));
+    m_requiredKeys.insert("dest_path", new DataValue(true));
+    m_requiredKeys.insert("*", new DataValue(false));
+}
+
+/**
+ * initBlossom
+ */
+void
+TemplateCreateStringBlossom::initBlossom(BlossomItem &blossomItem)
+{
+    m_templatePath = blossomItem.values.getValueAsString("source_path");
+    m_destinationPath = blossomItem.values.getValueAsString("dest_path");
+
+    // create source-path
+    m_templatePath = SakuraRoot::m_currentGarden->getRelativePath(blossomItem.blossomPath,
+                                                                  m_templatePath,
+                                                                  "templates");
+
+    blossomItem.success = true;
+}
+
+/**
+ * preCheck
+ */
+void
+TemplateCreateStringBlossom::preCheck(BlossomItem &blossomItem)
+{
+    // read template-file
+    std::string fileContent = SakuraRoot::m_currentGarden->getTemplate(m_templatePath);
+    if(fileContent == "")
+    {
+        blossomItem.success = false;
+        blossomItem.outputMessage = "couldn't find template-file " + m_templatePath;
+        return;
+    }
+
+    DataMap inputData;
+    std::map<std::string, ValueItem>::iterator it;
+    for(it = blossomItem.values.begin();
+        it != blossomItem.values.end();
+        it++)
+    {
+        if(it->second.item != nullptr) {
+            inputData.insert(it->first, it->second.item->copy());
+        }
+    }
+
+    // create file-content form template
+    std::string errorMessage;
+    bool jinja2Result = SakuraRoot::m_root->m_jinja2Converter->convert(m_fileContent,
+                                                                       fileContent,
+                                                                       &inputData,
+                                                                       errorMessage);
+    if(jinja2Result == false)
+    {
+        blossomItem.success = false;
+        blossomItem.outputMessage = "couldn't convert template-file "
+                                   + m_templatePath +
+                                   " with reason: "
+                                   + errorMessage;
+        return;
+    }
+
+    // check if template-file already exist
+    if(Kitsunemimi::Persistence::doesPathExist(m_destinationPath))
+    {
+        // read the already existing file and compare it the current file-content
+        errorMessage.clear();
+        fileContent.clear();
+        bool results = Kitsunemimi::Persistence::readFile(fileContent,
+                                                          m_destinationPath,
+                                                          errorMessage);
+        if(results == true
+                && m_fileContent == fileContent)
+        {
+            blossomItem.skip = true;
+            blossomItem.success = true;
+            return;
+        }
+    }
+
+    blossomItem.success = true;
+}
+
+/**
+ * runTask
+ */
+void
+TemplateCreateStringBlossom::runTask(BlossomItem &blossomItem)
+{
+    std::string errorMessage = "";
+    bool writeResult = Kitsunemimi::Persistence::writeFile(m_destinationPath,
+                                                           m_fileContent,
+                                                           errorMessage,
+                                                           true);
+    if(writeResult == false)
+    {
+        blossomItem.success = false;
+        blossomItem.outputMessage = "couldn't write file "
+                                   + m_destinationPath +
+                                   " with reason: "
+                                   + errorMessage;
+        return;
+    }
+
+    blossomItem.success = true;
+}
+
+/**
+ * postCheck
+ */
+void
+TemplateCreateStringBlossom::postCheck(BlossomItem &blossomItem)
+{
+    std::string errorMessage = "";
+    std::string fileContent = "";
+    bool ret = Kitsunemimi::Persistence::readFile(fileContent, m_destinationPath, errorMessage);
+    if(ret == false
+            || m_fileContent != fileContent)
+    {
+        blossomItem.success = false;
+        return;
+    }
+
+    blossomItem.success = true;
+}
+
+/**
+ * closeBlossom
+ */
+void
+TemplateCreateStringBlossom::closeBlossom(BlossomItem &blossomItem)
+{
+    blossomItem.success = true;
+}
+
+}

--- a/src/processing/blossoms/files/template_files/template_create_string_blossom.h
+++ b/src/processing/blossoms/files/template_files/template_create_string_blossom.h
@@ -46,7 +46,7 @@ private:
     std::string m_templatePath = "";
     std::string m_destinationPath = "";
 
-    std::string m_fileContent = "";
+    std::string m_convertedContent = "";
 };
 
 }

--- a/src/processing/blossoms/files/template_files/template_create_string_blossom.h
+++ b/src/processing/blossoms/files/template_files/template_create_string_blossom.h
@@ -44,9 +44,6 @@ protected:
 
 private:
     std::string m_templatePath = "";
-    std::string m_destinationPath = "";
-
-    std::string m_convertedContent = "";
 };
 
 }

--- a/src/processing/blossoms/files/template_files/template_create_string_blossom.h
+++ b/src/processing/blossoms/files/template_files/template_create_string_blossom.h
@@ -1,5 +1,5 @@
 /**
- * @file        template_create_blossom.h
+ * @file        template_create_string_blossom.h
  *
  * @author      Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
@@ -20,21 +20,20 @@
  *      limitations under the License.
  */
 
-#ifndef TEMPLATE_BLOSSOM_H
-#define TEMPLATE_BLOSSOM_H
+#ifndef TEMPLATE_CREATE_STRING_BLOSSOM_H
+#define TEMPLATE_CREATE_STRING_BLOSSOM_H
 
 #include <processing/blossoms/blossom.h>
 
 namespace SakuraTree
 {
-class TemplateCreateBlossom_Test;
 
-class TemplateCreateBlossom
+class TemplateCreateStringBlossom
         : public Blossom
 {
 
 public:
-    TemplateCreateBlossom();
+    TemplateCreateStringBlossom();
 
 protected:
     void initBlossom(BlossomItem &blossomItem);
@@ -44,8 +43,6 @@ protected:
     void closeBlossom(BlossomItem &blossomItem);
 
 private:
-    friend TemplateCreateBlossom_Test;
-
     std::string m_templatePath = "";
     std::string m_destinationPath = "";
 
@@ -54,4 +51,4 @@ private:
 
 }
 
-#endif // TEMPLATE_BLOSSOM_H
+#endif // TEMPLATE_CREATE_STRING_BLOSSOM_H

--- a/src/processing/blossoms/files/template_files/template_methods.cpp
+++ b/src/processing/blossoms/files/template_files/template_methods.cpp
@@ -1,0 +1,83 @@
+/**
+ * @file        template_methods.cpp
+ *
+ * @author      Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ * @copyright   Apache License Version 2.0
+ *
+ *      Copyright 2019 Tobias Anker
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+#include "template_methods.h"
+
+#include <libKitsunemimiJinja2/jinja2_converter.h>
+
+namespace SakuraTree
+{
+
+/**
+ * @brief convert a jinja2-template with values into a new string
+ *
+ * @param output reference for the converted output-string
+ * @param templatePath relative-path to the template-file within the sakura-garden
+ * @param values value-item-map with all values, which should be inserted into the template
+ * @param errorMessage reference-string for output of the error-message in case of an error
+ *
+ * @return true, if successful, else false
+ */
+bool
+convertTemplate(std::string &output,
+                const std::string &templatePath,
+                const ValueItemMap &values,
+                std::string &errorMessage)
+{
+    // read template-file
+    const std::string templateFileContent = SakuraRoot::m_currentGarden->getTemplate(templatePath);
+    if(templateFileContent == "")
+    {
+        errorMessage = "couldn't find template-file " + templatePath;
+        return false;
+    }
+
+    // convert value-item-map into data-map to be processable by the jinja2-library
+    DataMap inputData;
+    std::map<std::string, ValueItem>::const_iterator it;
+    for(it = values.const_begin();
+        it != values.const_end();
+        it++)
+    {
+        if(it->second.item != nullptr) {
+            inputData.insert(it->first, it->second.item->copy());
+        }
+    }
+
+    // create file-content form template
+    bool jinja2Result = SakuraRoot::m_root->m_jinja2Converter->convert(output,
+                                                                       templateFileContent,
+                                                                       &inputData,
+                                                                       errorMessage);
+    if(jinja2Result == false)
+    {
+        errorMessage = "couldn't convert template-file "
+                       + templatePath +
+                       " with reason: "
+                       + errorMessage;
+        return false;
+    }
+
+    return true;
+}
+
+}

--- a/src/processing/blossoms/files/template_files/template_methods.cpp
+++ b/src/processing/blossoms/files/template_files/template_methods.cpp
@@ -54,8 +54,8 @@ convertTemplate(std::string &output,
     // convert value-item-map into data-map to be processable by the jinja2-library
     DataMap inputData;
     std::map<std::string, ValueItem>::const_iterator it;
-    for(it = values.const_begin();
-        it != values.const_end();
+    for(it = values.m_valueMap.begin();
+        it != values.m_valueMap.end();
         it++)
     {
         if(it->second.item != nullptr) {

--- a/src/processing/blossoms/files/template_files/template_methods.cpp
+++ b/src/processing/blossoms/files/template_files/template_methods.cpp
@@ -51,11 +51,25 @@ convertTemplate(std::string &output,
         return false;
     }
 
+    // get variables
+    ValueItemMap* variables = nullptr;
+    std::map<std::string, ValueItemMap*>::const_iterator variablesIt;
+    variablesIt = values.m_childMaps.find("variables");
+    if(variablesIt != values.m_childMaps.end())
+    {
+        variables = variablesIt->second;
+    }
+    else
+    {
+        errorMessage = "couldn't find variables in the template-values";
+        return false;
+    }
+
     // convert value-item-map into data-map to be processable by the jinja2-library
     DataMap inputData;
     std::map<std::string, ValueItem>::const_iterator it;
-    for(it = values.m_valueMap.begin();
-        it != values.m_valueMap.end();
+    for(it = variables->m_valueMap.begin();
+        it != variables->m_valueMap.end();
         it++)
     {
         if(it->second.item != nullptr) {

--- a/src/processing/blossoms/files/template_files/template_methods.h
+++ b/src/processing/blossoms/files/template_files/template_methods.h
@@ -1,5 +1,5 @@
 /**
- * @file        template_create_file_blossom.h
+ * @file        template_methods.h
  *
  * @author      Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
@@ -20,38 +20,20 @@
  *      limitations under the License.
  */
 
-#ifndef TEMPLATE_CREATE_FILE_BLOSSOM_H
-#define TEMPLATE_CREATE_FILE_BLOSSOM_H
+#ifndef TEMPLATE_METHODS_H
+#define TEMPLATE_METHODS_H
 
-#include <processing/blossoms/blossom.h>
+#include <common.h>
+#include <sakura_root.h>
 
 namespace SakuraTree
 {
-class TemplateCreateBlossom_Test;
 
-class TemplateCreateFileBlossom
-        : public Blossom
-{
-
-public:
-    TemplateCreateFileBlossom();
-
-protected:
-    void initBlossom(BlossomItem &blossomItem);
-    void preCheck(BlossomItem &blossomItem);
-    void runTask(BlossomItem &blossomItem);
-    void postCheck(BlossomItem &blossomItem);
-    void closeBlossom(BlossomItem &blossomItem);
-
-private:
-    friend TemplateCreateBlossom_Test;
-
-    std::string m_templatePath = "";
-    std::string m_destinationPath = "";
-
-    std::string m_convertedContent = "";
-};
+bool convertTemplate(std::string &output,
+                     const std::string &templatePath,
+                     const ValueItemMap &values,
+                     std::string &errorMessage);
 
 }
 
-#endif // TEMPLATE_CREATE_FILE_BLOSSOM_H
+#endif // TEMPLATE_METHODS_H

--- a/src/processing/blossoms/special/assert_blossom.cpp
+++ b/src/processing/blossoms/special/assert_blossom.cpp
@@ -56,8 +56,8 @@ void
 AssertBlossom::runTask(BlossomItem &blossomItem)
 {
     std::map<std::string, ValueItem>::iterator it;
-    for(it = blossomItem.values.begin();
-        it != blossomItem.values.end();
+    for(it = blossomItem.values.m_valueMap.begin();
+        it != blossomItem.values.m_valueMap.end();
         it++)
     {
         const std::string isValue = blossomItem.parentValues->get(it->first)->toString();

--- a/src/processing/blossoms/special/print_blossom.cpp
+++ b/src/processing/blossoms/special/print_blossom.cpp
@@ -64,8 +64,8 @@ PrintBlossom::runTask(BlossomItem &blossomItem)
     tableItem.addColumn("value", "Value");
 
     std::map<std::string, ValueItem>::iterator it;
-    for(it = blossomItem.values.begin();
-        it != blossomItem.values.end();
+    for(it = blossomItem.values.m_valueMap.begin();
+        it != blossomItem.values.m_valueMap.end();
         it++)
     {
         tableItem.addRow(std::vector<std::string>{it->first, it->second.item->toString(true)});

--- a/src/processing/common/item_methods.cpp
+++ b/src/processing/common/item_methods.cpp
@@ -308,6 +308,17 @@ fillInputValueItemMap(ValueItemMap &items,
         }
     }
 
+    std::map<std::string, ValueItemMap*>::iterator itChild;
+    for(itChild = items.m_childMaps.begin();
+        itChild != items.m_childMaps.end();
+        itChild++)
+    {
+        const bool ret = fillInputValueItemMap(*itChild->second, insertValues, errorMessage);
+        if(ret == false) {
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/src/processing/common/item_methods.cpp
+++ b/src/processing/common/item_methods.cpp
@@ -299,8 +299,8 @@ fillInputValueItemMap(ValueItemMap &items,
     Result result;
 
     std::map<std::string, ValueItem>::iterator it;
-    for(it = items.begin();
-        it != items.end();
+    for(it = items.m_valueMap.begin();
+        it != items.m_valueMap.end();
         it++)
     {
         if(fillValueItem(it->second, insertValues, errorMessage) == false) {
@@ -326,8 +326,8 @@ fillOutputValueItemMap(ValueItemMap &items,
     bool found = false;
 
     std::map<std::string, ValueItem>::iterator it;
-    for(it = items.begin();
-        it != items.end();
+    for(it = items.m_valueMap.begin();
+        it != items.m_valueMap.end();
         it++)
     {
         // replace only as output-marked values
@@ -399,8 +399,8 @@ overrideItems(DataMap &original,
     if(onlyExisting)
     {
         std::map<std::string, ValueItem>::const_iterator overrideIt;
-        for(overrideIt = override.const_begin();
-            overrideIt != override.const_end();
+        for(overrideIt = override.m_valueMap.begin();
+            overrideIt != override.m_valueMap.end();
             overrideIt++)
         {
             std::map<std::string, DataItem*>::iterator originalIt;
@@ -414,8 +414,8 @@ overrideItems(DataMap &original,
     else
     {
         std::map<std::string, ValueItem>::const_iterator overrideIt;
-        for(overrideIt = override.const_begin();
-            overrideIt != override.const_end();
+        for(overrideIt = override.m_valueMap.begin();
+            overrideIt != override.m_valueMap.end();
             overrideIt++)
         {
             original.insert(overrideIt->first, overrideIt->second.item->copy(), true);
@@ -443,14 +443,14 @@ overrideItems(ValueItemMap &original,
     if(onlyExisting)
     {
         std::map<std::string, ValueItem>::const_iterator overrideIt;
-        for(overrideIt = override.const_begin();
-            overrideIt != override.const_end();
+        for(overrideIt = override.m_valueMap.begin();
+            overrideIt != override.m_valueMap.end();
             overrideIt++)
         {
             std::map<std::string, ValueItem>::iterator originalIt;
-            originalIt = original.find(overrideIt->first);
+            originalIt = original.m_valueMap.find(overrideIt->first);
 
-            if(originalIt != original.end())
+            if(originalIt != original.m_valueMap.end())
             {
                 ValueItem temp = overrideIt->second;
                 original.insert(overrideIt->first, temp, true);
@@ -460,14 +460,14 @@ overrideItems(ValueItemMap &original,
     else if(onlyNotExisting)
     {
         std::map<std::string, ValueItem>::const_iterator overrideIt;
-        for(overrideIt = override.const_begin();
-            overrideIt != override.const_end();
+        for(overrideIt = override.m_valueMap.begin();
+            overrideIt != override.m_valueMap.end();
             overrideIt++)
         {
             std::map<std::string, ValueItem>::iterator originalIt;
-            originalIt = original.find(overrideIt->first);
+            originalIt = original.m_valueMap.find(overrideIt->first);
 
-            if(originalIt == original.end())
+            if(originalIt == original.m_valueMap.end())
             {
                 ValueItem temp = overrideIt->second;
                 original.insert(overrideIt->first, temp, true);
@@ -477,8 +477,8 @@ overrideItems(ValueItemMap &original,
     else
     {
         std::map<std::string, ValueItem>::const_iterator overrideIt;
-        for(overrideIt = override.const_begin();
-            overrideIt != override.const_end();
+        for(overrideIt = override.m_valueMap.begin();
+            overrideIt != override.m_valueMap.end();
             overrideIt++)
         {
             ValueItem temp = overrideIt->second;

--- a/src/processing/sakura_thread.cpp
+++ b/src/processing/sakura_thread.cpp
@@ -389,8 +389,8 @@ SakuraThread::processSubtree(SubtreeItem* subtreeItem,
         DataMap* tempMap = new DataMap();
 
         std::map<std::string, ValueItem>::iterator valueIt;
-        for(valueIt = mapIt->second.begin();
-            valueIt != mapIt->second.end();
+        for(valueIt = mapIt->second.m_valueMap.begin();
+            valueIt != mapIt->second.m_valueMap.end();
             valueIt++)
         {
             errorMessage = "";

--- a/tests/processing/blossoms/files/template_files/template_create_blossom_test.cpp
+++ b/tests/processing/blossoms/files/template_files/template_create_blossom_test.cpp
@@ -21,7 +21,7 @@
  */
 
 #include "template_create_blossom_test.h"
-#include <processing/blossoms/files/template_files/template_create_blossom.h>
+#include <processing/blossoms/files/template_files/template_create_file_blossom.h>
 #include <libKitsunemimiPersistence/files/text_file.h>
 
 namespace SakuraTree
@@ -69,7 +69,7 @@ TemplateCreateBlossom_Test::initTask_test()
 {
     BlossomItem fakeItem;
     fakeItem.blossomPath = "/tmp/";
-    TemplateCreateBlossom fakeCreateBlossom;
+    TemplateCreateFileBlossom fakeCreateBlossom;
 
     fakeItem.values.insert("source_path", new DataValue(m_localTemplatePath));
     fakeItem.values.insert("dest_path", new DataValue(m_destinationFile));
@@ -96,7 +96,7 @@ TemplateCreateBlossom_Test::preCheck_test()
     fakeItem.blossomPath = "/tmp/";
     fakeItem.values.insert("source_path", new DataValue(m_localTemplatePath));
     fakeItem.values.insert("dest_path", new DataValue(m_destinationFile));
-    TemplateCreateBlossom fakeCopyBlossom;
+    TemplateCreateFileBlossom fakeCopyBlossom;
 
     fakeCopyBlossom.initBlossom(fakeItem);
     fakeCopyBlossom.preCheck(fakeItem);
@@ -140,7 +140,7 @@ TemplateCreateBlossom_Test::runTask_test()
     fakeItem.blossomPath = "/tmp/";
     fakeItem.values.insert("source_path", new DataValue(m_localTemplatePath));
     fakeItem.values.insert("dest_path", new DataValue(m_destinationFile));
-    TemplateCreateBlossom fakeCopyBlossom;
+    TemplateCreateFileBlossom fakeCopyBlossom;
 
     fakeCopyBlossom.initBlossom(fakeItem);
     fakeCopyBlossom.runTask(fakeItem);
@@ -159,7 +159,7 @@ TemplateCreateBlossom_Test::postCheck_test()
     fakeItem.blossomPath = "/tmp/";
     fakeItem.values.insert("source_path", new DataValue(m_localTemplatePath));
     fakeItem.values.insert("dest_path", new DataValue(m_destinationFile));
-    TemplateCreateBlossom fakeCopyBlossom;
+    TemplateCreateFileBlossom fakeCopyBlossom;
 
     fakeCopyBlossom.initBlossom(fakeItem);
     fakeCopyBlossom.runTask(fakeItem);
@@ -181,7 +181,7 @@ TemplateCreateBlossom_Test::closeTask_test()
     fakeItem.blossomPath = "/tmp/";
     fakeItem.values.insert("source_path", new DataValue(m_localTemplatePath));
     fakeItem.values.insert("dest_path", new DataValue(m_destinationFile));
-    TemplateCreateBlossom fakeCopyBlossom;
+    TemplateCreateFileBlossom fakeCopyBlossom;
 
     fakeCopyBlossom.initBlossom(fakeItem);
     fakeCopyBlossom.closeBlossom(fakeItem);


### PR DESCRIPTION
## Description

Update template-blossom:

- variables are given now by a new section to encapsulate the values, which should be written into the template
- add possibility to set owner and permission for the written file
- add new tempalte-blossom to allow the write the converted content into a variable instead of a file 

## Related Issues

- #159 

## How it was tested?

example:

```
["test templates"]
- dest_path = "/tmp/test_template"
- converted_output = ""
- read_output = ""


template("create a template")
- source_path = "test_template.j2"
-> create_file:
    - dest_path = dest_path
    - owner = "neptune"
    - permission = 666
    - variables = { - checker = 42
					- name = "test-template" }
    
-> create_string:
    - variables = { - checker = 42
					- name = "test-template" }
    - blossom_output >> converted_output


text_file("read written file")
- file_path = dest_path
-> read:
    - blossom_output >> read_output


print("debug-output")
- converted_output = converted_output
- read_output = read_output


assert("compare")
- converted_output == read_output
```