### PR TITLE
Add json parser function

### DIFF
--- a/examples/parse-json-test/root.sakura
+++ b/examples/parse-json-test/root.sakura
@@ -1,0 +1,11 @@
+["parse json"]
+- input = "{ \"test\": 2, \"asdf\": { \"xyz\": 42 } }"
+- parsed_content = ""
+
+
+item_update("parse json")
+- parsed_content = input.parse_json()
+
+
+print("debug-output")
+- xyz = parsed_content.get("asdf").get("xyz")

--- a/src/processing/common/item_methods.cpp
+++ b/src/processing/common/item_methods.cpp
@@ -165,6 +165,18 @@ getProcessedItem(ValueItem &valueItem,
             continue;
         }
         //------------------------------------------------------------------------------------------
+        if(type == "parse_json")
+        {
+            if(functionItem.arguments.size() != 0) {
+                return false;
+            }
+
+            valueItem.item = parseJson(valueItem.item->toValue(),
+                                       errorMessage);
+
+            continue;
+        }
+        //------------------------------------------------------------------------------------------
 
         valueItem.item = nullptr;
     }

--- a/src/processing/common/value_item_functions.cpp
+++ b/src/processing/common/value_item_functions.cpp
@@ -22,6 +22,7 @@
 
 #include <processing/common/value_item_functions.h>
 #include <libKitsunemimiCommon/common_methods/string_methods.h>
+#include <libKitsunemimiJson/json_item.h>
 
 using Kitsunemimi::splitStringByDelimiter;
 
@@ -320,4 +321,34 @@ clearEmpty(DataArray* item,
     }
 
     return result;
+}
+
+/**
+ * @brief parse a json-formated string into a data-item
+ *
+ * @param intput input-value with the json-formated content
+ * @param errorMessage error-message for output
+ *
+ * @return nullptr, if failed, else a data-item with the parsed content
+ */
+DataItem*
+parseJson(DataValue* intput,
+          std::string &errorMessage)
+{
+    // precheck
+    if(intput == nullptr)
+    {
+        errorMessage = "inputs for size-function are invalid";
+        return nullptr;
+    }
+
+    // try to parse json
+    Kitsunemimi::Json::JsonItem jsonItem;
+    if(jsonItem.parse(intput->toString(), errorMessage))
+    {
+        DataItem* resultItem = jsonItem.getItemContent()->copy();
+        return resultItem;
+    }
+
+    return nullptr;
 }

--- a/src/processing/common/value_item_functions.h
+++ b/src/processing/common/value_item_functions.h
@@ -32,5 +32,7 @@ DataValue* containsValue(DataItem* item, DataValue* key, std::string &errorMessa
 DataArray* appendValue(DataArray* item, DataItem* value, std::string &errorMessage);
 DataMap* insertValue(DataMap* item, DataValue* key, DataItem* value, std::string &errorMessage);
 DataArray* clearEmpty(DataArray* item, std::string &errorMessage);
+DataItem* parseJson(DataValue* intput, std::string &errorMessage);
+
 
 #endif // VALUE_ITEM_FUNCTIONS_H


### PR DESCRIPTION
## Description

Add json parser function

## Related Issues

- #179 

## How it was tested?

- new example:

```
["parse json"]
- input = "{ \"test\": 2, \"asdf\": { \"xyz\": 42 } }"
- parsed_content = ""


item_update("parse json")
- parsed_content = input.parse_json()


print("debug-output")
- xyz = parsed_content.get("asdf").get("xyz")
```
