### PR TITLE
remove SakuraTree-namespace from all files, because its not necessary

### DIFF
--- a/src/common/typedefs.h
+++ b/src/common/typedefs.h
@@ -42,10 +42,8 @@ struct Result
     DataItem* item = nullptr;
 };
 
-namespace SakuraTree {
 class SakuraBranch;
-}
-typedef std::map<std::string, SakuraTree::SakuraBranch*> BranchMap;
+typedef std::map<std::string, SakuraBranch*> BranchMap;
 
 
 #endif // TYPEDEFS_H

--- a/src/config.h
+++ b/src/config.h
@@ -1,11 +1,30 @@
+/**
+ * @file        config.h
+ *
+ * @author      Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ * @copyright   Apache License Version 2.0
+ *
+ *      Copyright 2019 Tobias Anker
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
 #ifndef CONFIG_H
 #define CONFIG_H
 
 #include <common.h>
 #include <libKitsunemimiConfig/config_handler.h>
-
-namespace SakuraTree
-{
 
 void
 registerConfigs()
@@ -13,8 +32,6 @@ registerConfigs()
     assert(REGISTER_BOOL_CONFIG("DEFAULT", "debug", false));
     assert(REGISTER_INT_CONFIG("server", "server_port", 1337));
     assert(REGISTER_STRING_CONFIG("server", "server_address", "127.0.0.1"));
-}
-
 }
 
 #endif // CONFIG_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,8 +94,8 @@ int main(int argc, char *argv[])
     }
     std::cout<<"absolute input-path: "<<inputPath<<std::endl;
 
-    SakuraTree::SakuraRoot* root = new SakuraTree::SakuraRoot(std::string(argv[0]),
-                                                              enableDebug);
+    SakuraRoot* root = new SakuraRoot(std::string(argv[0]),
+                                                  enableDebug);
 
     if(argParser.wasSet("use-config"))
     {

--- a/src/processing/blossoms/blossom.cpp
+++ b/src/processing/blossoms/blossom.cpp
@@ -24,9 +24,6 @@
 #include <sakura_root.h>
 #include <processing/common/item_methods.h>
 
-namespace SakuraTree
-{
-
 Blossom::Blossom() {}
 
 Blossom::~Blossom() {}
@@ -101,6 +98,4 @@ Blossom::growBlossom(BlossomItem &blossomItem,
     //----------------------------------------------------------------------------------------------
 
     return;
-}
-
 }

--- a/src/processing/blossoms/blossom.h
+++ b/src/processing/blossoms/blossom.h
@@ -28,9 +28,6 @@
 #include <processing/common/item_methods.h>
 #include <libKitsunemimiPersistence/logger/logger.h>
 
-namespace SakuraTree
-{
-
 class Blossom
 {
 public:
@@ -50,7 +47,5 @@ protected:
     virtual void postCheck(BlossomItem &blossomItem) = 0;
     virtual void closeBlossom(BlossomItem &blossomItem) = 0;
 };
-
-}
 
 #endif // BLOSSOM_H

--- a/src/processing/blossoms/blossom_getter.cpp
+++ b/src/processing/blossoms/blossom_getter.cpp
@@ -57,9 +57,6 @@
 #include <processing/blossoms/files/ini_files/ini_read_entry_blossom.h>
 #include <processing/blossoms/files/ini_files/ini_set_entry_blossom.h>
 
-namespace SakuraTree
-{
-
 /**
  * request a new blossom-object to process the requested task
  *
@@ -180,6 +177,4 @@ getBlossom(const std::string blossomGroupType,
     }
 
     return nullptr;
-}
-
 }

--- a/src/processing/blossoms/blossom_getter.h
+++ b/src/processing/blossoms/blossom_getter.h
@@ -25,13 +25,9 @@
 
 #include <common.h>
 
-namespace SakuraTree
-{
 class Blossom;
 
 Blossom* getBlossom(const std::string blossomGroupType,
                     const std::string blossomType);
-
-}
 
 #endif // BLOSSOM_GETTER_H

--- a/src/processing/blossoms/files/common_files/path_chmod_blossom.cpp
+++ b/src/processing/blossoms/files/common_files/path_chmod_blossom.cpp
@@ -23,9 +23,6 @@
 #include "path_chmod_blossom.h"
 #include <libKitsunemimiPersistence/files/file_methods.h>
 
-namespace SakuraTree
-{
-
 PathChmodBlossom::PathChmodBlossom()
     : Blossom()
 {
@@ -99,6 +96,4 @@ void
 PathChmodBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/common_files/path_chmod_blossom.h
+++ b/src/processing/blossoms/files/common_files/path_chmod_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class PathChmodBlossom
         : public Blossom
 {
@@ -45,7 +42,5 @@ private:
     std::string m_path = "";
     std::string m_permission = "";
 };
-
-}
 
 #endif // PATH_CHMOD_BLOSSOM_H

--- a/src/processing/blossoms/files/common_files/path_chown_blossom.cpp
+++ b/src/processing/blossoms/files/common_files/path_chown_blossom.cpp
@@ -23,9 +23,6 @@
 #include "path_chown_blossom.h"
 #include <libKitsunemimiPersistence/files/file_methods.h>
 
-namespace SakuraTree
-{
-
 PathChownBlossom::PathChownBlossom()
     : Blossom()
 {
@@ -99,6 +96,4 @@ void
 PathChownBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/common_files/path_chown_blossom.h
+++ b/src/processing/blossoms/files/common_files/path_chown_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class PathChownBlossom
         : public Blossom
 {
@@ -45,7 +42,5 @@ private:
     std::string m_path = "";
     std::string m_owner = "";
 };
-
-}
 
 #endif // PATH_CHOWN_BLOSSOM_H

--- a/src/processing/blossoms/files/common_files/path_copy_blossom.cpp
+++ b/src/processing/blossoms/files/common_files/path_copy_blossom.cpp
@@ -26,8 +26,6 @@
 #include <libKitsunemimiPersistence/files/binary_file.h>
 #include <libKitsunemimiCommon/common_methods/string_methods.h>
 
-namespace SakuraTree
-{
 using Kitsunemimi::splitStringByDelimiter;
 
 PathCopyBlossom::PathCopyBlossom()
@@ -201,6 +199,4 @@ void
 PathCopyBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/common_files/path_copy_blossom.h
+++ b/src/processing/blossoms/files/common_files/path_copy_blossom.h
@@ -25,8 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
 class PathCopyBlossom_Test;
 
 class PathCopyBlossom
@@ -51,7 +49,5 @@ private:
     std::string m_owner = "";
     bool m_localStorage = false;
 };
-
-}
 
 #endif // PATH_COPY_BLOSSOM_H

--- a/src/processing/blossoms/files/common_files/path_delete_blossom.cpp
+++ b/src/processing/blossoms/files/common_files/path_delete_blossom.cpp
@@ -23,9 +23,6 @@
 #include "path_delete_blossom.h"
 #include <libKitsunemimiPersistence/files/file_methods.h>
 
-namespace SakuraTree
-{
-
 PathDeleteBlossom::PathDeleteBlossom()
     : Blossom()
 {
@@ -101,6 +98,4 @@ void
 PathDeleteBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/common_files/path_delete_blossom.h
+++ b/src/processing/blossoms/files/common_files/path_delete_blossom.h
@@ -25,8 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
 class PathDeleteBlossom_Test;
 
 class PathDeleteBlossom
@@ -47,7 +45,5 @@ private:
 
     std::string m_path = "";
 };
-
-}
 
 #endif // PATH_DELETE_BLOSSOM_H

--- a/src/processing/blossoms/files/common_files/path_rename_blossom.cpp
+++ b/src/processing/blossoms/files/common_files/path_rename_blossom.cpp
@@ -25,8 +25,6 @@
 #include <libKitsunemimiCommon/common_methods/string_methods.h>
 #include <libKitsunemimiCommon/common_methods/vector_methods.h>
 
-namespace SakuraTree
-{
 using Kitsunemimi::splitStringByDelimiter;
 
 PathRenameBlossom::PathRenameBlossom()
@@ -139,6 +137,4 @@ void
 PathRenameBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/common_files/path_rename_blossom.h
+++ b/src/processing/blossoms/files/common_files/path_rename_blossom.h
@@ -25,8 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
 class PathRenameBlossom_Test;
 
 class PathRenameBlossom
@@ -49,7 +47,5 @@ private:
     std::string m_newFileName = "";
     std::string m_newFilePath = "";
 };
-
-}
 
 #endif // PATH_RENAME_BLOSSOM_H

--- a/src/processing/blossoms/files/ini_files/ini_delete_entry_blossom.cpp
+++ b/src/processing/blossoms/files/ini_files/ini_delete_entry_blossom.cpp
@@ -27,9 +27,6 @@
 
 using Kitsunemimi::Ini::IniItem;
 
-namespace SakuraTree
-{
-
 IniDeleteEntryBlossom::IniDeleteEntryBlossom()
     : Blossom()
 {
@@ -123,6 +120,4 @@ void
 IniDeleteEntryBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/ini_files/ini_delete_entry_blossom.h
+++ b/src/processing/blossoms/files/ini_files/ini_delete_entry_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class IniDeleteEntryBlossom
         : public Blossom
 {
@@ -46,7 +43,5 @@ private:
     std::string m_group = "";
     std::string m_entry = "";
 };
-
-}
 
 #endif // INI_DELETE_ENTRY_BLOSSOM_H

--- a/src/processing/blossoms/files/ini_files/ini_read_entry_blossom.cpp
+++ b/src/processing/blossoms/files/ini_files/ini_read_entry_blossom.cpp
@@ -27,9 +27,6 @@
 
 using Kitsunemimi::Ini::IniItem;
 
-namespace SakuraTree
-{
-
 IniReadEntryBlossom::IniReadEntryBlossom()
     : Blossom()
 {
@@ -119,6 +116,4 @@ void
 IniReadEntryBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/ini_files/ini_read_entry_blossom.h
+++ b/src/processing/blossoms/files/ini_files/ini_read_entry_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class IniReadEntryBlossom
         : public Blossom
 {
@@ -46,7 +43,5 @@ private:
     std::string m_group = "";
     std::string m_entry = "";
 };
-
-}
 
 #endif // INI_READ_ENTRY_BLOSSOM_H

--- a/src/processing/blossoms/files/ini_files/ini_set_entry_blossom.cpp
+++ b/src/processing/blossoms/files/ini_files/ini_set_entry_blossom.cpp
@@ -27,9 +27,6 @@
 
 using Kitsunemimi::Ini::IniItem;
 
-namespace SakuraTree
-{
-
 IniSetEntryBlossom::IniSetEntryBlossom()
     : Blossom()
 {
@@ -134,6 +131,4 @@ void
 IniSetEntryBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/ini_files/ini_set_entry_blossom.h
+++ b/src/processing/blossoms/files/ini_files/ini_set_entry_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class IniSetEntryBlossom
         : public Blossom
 {
@@ -47,7 +44,5 @@ private:
     std::string m_entry = "";
     std::string m_value = "";
 };
-
-}
 
 #endif // INI_SET_ENTRY_BLOSSOM_H

--- a/src/processing/blossoms/files/template_files/template_create_file_blossom.cpp
+++ b/src/processing/blossoms/files/template_files/template_create_file_blossom.cpp
@@ -28,9 +28,6 @@
 #include <libKitsunemimiPersistence/files/file_methods.h>
 #include <libKitsunemimiPersistence/files/text_file.h>
 
-namespace SakuraTree
-{
-
 TemplateCreateFileBlossom::TemplateCreateFileBlossom()
     : Blossom()
 {
@@ -185,6 +182,4 @@ void
 TemplateCreateFileBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/template_files/template_create_file_blossom.h
+++ b/src/processing/blossoms/files/template_files/template_create_file_blossom.h
@@ -25,8 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
 class TemplateCreateBlossom_Test;
 
 class TemplateCreateFileBlossom
@@ -53,7 +51,5 @@ private:
 
     std::string m_convertedContent = "";
 };
-
-}
 
 #endif // TEMPLATE_CREATE_FILE_BLOSSOM_H

--- a/src/processing/blossoms/files/template_files/template_create_string_blossom.cpp
+++ b/src/processing/blossoms/files/template_files/template_create_string_blossom.cpp
@@ -25,9 +25,6 @@
 
 #include <sakura_root.h>
 
-namespace SakuraTree
-{
-
 TemplateCreateStringBlossom::TemplateCreateStringBlossom()
     : Blossom()
 {
@@ -94,6 +91,4 @@ void
 TemplateCreateStringBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/template_files/template_create_string_blossom.h
+++ b/src/processing/blossoms/files/template_files/template_create_string_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class TemplateCreateStringBlossom
         : public Blossom
 {
@@ -45,7 +42,5 @@ protected:
 private:
     std::string m_templatePath = "";
 };
-
-}
 
 #endif // TEMPLATE_CREATE_STRING_BLOSSOM_H

--- a/src/processing/blossoms/files/template_files/template_methods.cpp
+++ b/src/processing/blossoms/files/template_files/template_methods.cpp
@@ -24,9 +24,6 @@
 
 #include <libKitsunemimiJinja2/jinja2_converter.h>
 
-namespace SakuraTree
-{
-
 /**
  * @brief convert a jinja2-template with values into a new string
  *
@@ -92,6 +89,4 @@ convertTemplate(std::string &output,
     }
 
     return true;
-}
-
 }

--- a/src/processing/blossoms/files/template_files/template_methods.h
+++ b/src/processing/blossoms/files/template_files/template_methods.h
@@ -26,14 +26,9 @@
 #include <common.h>
 #include <sakura_root.h>
 
-namespace SakuraTree
-{
-
 bool convertTemplate(std::string &output,
                      const std::string &templatePath,
                      const ValueItemMap &values,
                      std::string &errorMessage);
-
-}
 
 #endif // TEMPLATE_METHODS_H

--- a/src/processing/blossoms/files/text_files/text_append_blossom.cpp
+++ b/src/processing/blossoms/files/text_files/text_append_blossom.cpp
@@ -24,9 +24,6 @@
 #include <libKitsunemimiPersistence/files/file_methods.h>
 #include <libKitsunemimiPersistence/files/text_file.h>
 
-namespace SakuraTree
-{
-
 TextAppendBlossom::TextAppendBlossom()
     : Blossom()
 {
@@ -109,6 +106,4 @@ void
 TextAppendBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/text_files/text_append_blossom.h
+++ b/src/processing/blossoms/files/text_files/text_append_blossom.h
@@ -25,8 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
 class TextAppendBlossom_Test;
 
 class TextAppendBlossom
@@ -48,7 +46,5 @@ private:
     std::string m_filePath = "";
     std::string m_newText = "";
 };
-
-}
 
 #endif // TEXT_APPEND_BLOSSOM_H

--- a/src/processing/blossoms/files/text_files/text_read_blossom.cpp
+++ b/src/processing/blossoms/files/text_files/text_read_blossom.cpp
@@ -24,9 +24,6 @@
 #include <libKitsunemimiPersistence/files/file_methods.h>
 #include <libKitsunemimiPersistence/files/text_file.h>
 
-namespace SakuraTree
-{
-
 TextReadBlossom::TextReadBlossom()
     : Blossom()
 {
@@ -110,6 +107,4 @@ void
 TextReadBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/text_files/text_read_blossom.h
+++ b/src/processing/blossoms/files/text_files/text_read_blossom.h
@@ -25,8 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
 class TextReadBlossom_Test;
 
 class TextReadBlossom
@@ -47,7 +45,5 @@ private:
 
     std::string m_filePath = "";
 };
-
-}
 
 #endif // TEXT_READ_BLOSSOM_H

--- a/src/processing/blossoms/files/text_files/text_replace_blossom.cpp
+++ b/src/processing/blossoms/files/text_files/text_replace_blossom.cpp
@@ -24,9 +24,6 @@
 #include <libKitsunemimiPersistence/files/file_methods.h>
 #include <libKitsunemimiPersistence/files/text_file.h>
 
-namespace SakuraTree
-{
-
 TextReplaceBlossom::TextReplaceBlossom()
     : Blossom()
 {
@@ -113,6 +110,4 @@ void
 TextReplaceBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/text_files/text_replace_blossom.h
+++ b/src/processing/blossoms/files/text_files/text_replace_blossom.h
@@ -25,8 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
 class TextReplaceBlossom_Test;
 
 class TextReplaceBlossom
@@ -49,7 +47,5 @@ private:
     std::string m_oldText = "";
     std::string m_newText = "";
 };
-
-}
 
 #endif // TEXT_REPLACE_BLOSSOM_H

--- a/src/processing/blossoms/files/text_files/text_write_blossom.cpp
+++ b/src/processing/blossoms/files/text_files/text_write_blossom.cpp
@@ -24,9 +24,6 @@
 #include <libKitsunemimiPersistence/files/file_methods.h>
 #include <libKitsunemimiPersistence/files/text_file.h>
 
-namespace SakuraTree
-{
-
 TextWriteBlossom::TextWriteBlossom()
     : Blossom()
 {
@@ -93,6 +90,4 @@ void
 TextWriteBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/files/text_files/text_write_blossom.h
+++ b/src/processing/blossoms/files/text_files/text_write_blossom.h
@@ -25,8 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
 class TextWriteBlossom_Test;
 
 class TextWriteBlossom
@@ -48,7 +46,5 @@ private:
     std::string m_filePath = "";
     std::string m_text = "";
 };
-
-}
 
 #endif // TEXT_WRITE_BLOSSOM_H

--- a/src/processing/blossoms/install/apt/apt_absent_blossom.cpp
+++ b/src/processing/blossoms/install/apt/apt_absent_blossom.cpp
@@ -23,9 +23,6 @@
 #include "apt_absent_blossom.h"
 #include <processing/blossoms/install/apt/apt_methods.h>
 
-namespace SakuraTree
-{
-
 AptAbsentBlossom::AptAbsentBlossom()
     : Blossom()
 {
@@ -137,6 +134,4 @@ AptAbsentBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     m_packageNames.clear();
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/install/apt/apt_absent_blossom.h
+++ b/src/processing/blossoms/install/apt/apt_absent_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class AptAbsentBlossom
         : public Blossom
 {
@@ -45,7 +42,5 @@ protected:
 private:
     std::vector<std::string> m_packageNames;
 };
-
-}
 
 #endif // APT_ABSENT_BLOSSOM_H

--- a/src/processing/blossoms/install/apt/apt_latest_blossom.h
+++ b/src/processing/blossoms/install/apt/apt_latest_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class AptLatestBlossom
         : public Blossom
 {
@@ -45,7 +42,5 @@ protected:
 private:
     std::vector<std::string> m_packageNames;
 };
-
-}
 
 #endif // APT_LATEST_BLOSSOM_H

--- a/src/processing/blossoms/install/apt/apt_latest_bossom.cpp
+++ b/src/processing/blossoms/install/apt/apt_latest_bossom.cpp
@@ -23,9 +23,6 @@
 #include "apt_latest_blossom.h"
 #include <processing/blossoms/install/apt/apt_methods.h>
 
-namespace SakuraTree
-{
-
 AptLatestBlossom::AptLatestBlossom()
     : Blossom()
 {
@@ -131,6 +128,4 @@ AptLatestBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     m_packageNames.clear();
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/install/apt/apt_methods.cpp
+++ b/src/processing/blossoms/install/apt/apt_methods.cpp
@@ -26,9 +26,6 @@
 #include <libKitsunemimiCommon/common_items/data_items.h>
 #include <libKitsunemimiPersistence/logger/logger.h>
 
-namespace SakuraTree
-{
-
 /**
  * @brief isInstalled check for a specific package, if this is installed
  *
@@ -154,6 +151,4 @@ getInstalledPackages()
     Kitsunemimi::splitStringByDelimiter(result, processResult.processOutput, '\n');
 
     return result;
-}
-
 }

--- a/src/processing/blossoms/install/apt/apt_methods.h
+++ b/src/processing/blossoms/install/apt/apt_methods.h
@@ -25,9 +25,6 @@
 
 #include <common.h>
 
-namespace SakuraTree
-{
-
 bool isInstalled(const std::string &package);
 
 const std::string createPackageList(const std::vector<std::string> &packageList);
@@ -35,7 +32,5 @@ const std::string createPackageList(const std::vector<std::string> &packageList)
 const std::vector<std::string> getInstalledPackages(const std::vector<std::string> &packageList);
 const std::vector<std::string> getAbsendPackages(const std::vector<std::string> &packageList);
 const std::vector<std::string> getInstalledPackages();
-
-}
 
 #endif // APT_METHODS_H

--- a/src/processing/blossoms/install/apt/apt_present_blossom.h
+++ b/src/processing/blossoms/install/apt/apt_present_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class AptPresentBlossom
         : public Blossom
 {
@@ -45,7 +42,5 @@ protected:
 private:
     std::vector<std::string> m_packageNames;
 };
-
-}
 
 #endif // APT_PRESENT_BLOSSOM_H

--- a/src/processing/blossoms/install/apt/apt_present_bossom.cpp
+++ b/src/processing/blossoms/install/apt/apt_present_bossom.cpp
@@ -23,9 +23,6 @@
 #include "apt_present_blossom.h"
 #include <processing/blossoms/install/apt/apt_methods.h>
 
-namespace SakuraTree
-{
-
 AptPresentBlossom::AptPresentBlossom()
     : Blossom()
 {
@@ -137,6 +134,4 @@ AptPresentBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     m_packageNames.clear();
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/install/apt/apt_update_blossom.cpp
+++ b/src/processing/blossoms/install/apt/apt_update_blossom.cpp
@@ -23,9 +23,6 @@
 #include "apt_update_blossom.h"
 #include <processing/blossoms/install/apt/apt_methods.h>
 
-namespace SakuraTree
-{
-
 AptUdateBlossom::AptUdateBlossom()
     : Blossom() {}
 
@@ -77,6 +74,4 @@ void
 AptUdateBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/install/apt/apt_update_blossom.h
+++ b/src/processing/blossoms/install/apt/apt_update_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class AptUdateBlossom
         : public Blossom
 {
@@ -45,7 +42,5 @@ protected:
 private:
     std::vector<std::string> m_packageNames;
 };
-
-}
 
 #endif // APT_UPDATE_BLOSSOM_H

--- a/src/processing/blossoms/install/apt/apt_upgrade_blossom.cpp
+++ b/src/processing/blossoms/install/apt/apt_upgrade_blossom.cpp
@@ -23,9 +23,6 @@
 #include "apt_upgrade_blossom.h"
 #include <processing/blossoms/install/apt/apt_methods.h>
 
-namespace SakuraTree
-{
-
 AptUpgradeBlossom::AptUpgradeBlossom()
     : Blossom() {}
 
@@ -77,6 +74,4 @@ void
 AptUpgradeBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/install/apt/apt_upgrade_blossom.h
+++ b/src/processing/blossoms/install/apt/apt_upgrade_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class AptUpgradeBlossom
         : public Blossom
 {
@@ -46,7 +43,5 @@ private:
     std::string m_action = "";
     std::vector<std::string> m_packageNames;
 };
-
-}
 
 #endif // APT_UPGRADE_BLOSSOM_H

--- a/src/processing/blossoms/special/assert_blossom.cpp
+++ b/src/processing/blossoms/special/assert_blossom.cpp
@@ -22,9 +22,6 @@
 
 #include "assert_blossom.h"
 
-namespace SakuraTree
-{
-
 AssertBlossom::AssertBlossom()
     : Blossom()
 {
@@ -94,6 +91,4 @@ void
 AssertBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/special/assert_blossom.h
+++ b/src/processing/blossoms/special/assert_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class AssertBlossom
         : public Blossom
 {
@@ -42,7 +39,5 @@ protected:
     void postCheck(BlossomItem &blossomItem);
     void closeBlossom(BlossomItem &blossomItem);
 };
-
-}
 
 #endif // ASSERT_BLOSSOM_H

--- a/src/processing/blossoms/special/cmd_blossom.cpp
+++ b/src/processing/blossoms/special/cmd_blossom.cpp
@@ -24,9 +24,6 @@
 
 #include <libKitsunemimiCommon/common_methods/string_methods.h>
 
-namespace SakuraTree
-{
-
 CmdBlossom::CmdBlossom()
     : Blossom()
 {
@@ -129,6 +126,4 @@ void
 CmdBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/special/cmd_blossom.h
+++ b/src/processing/blossoms/special/cmd_blossom.h
@@ -25,8 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
 class CmdBlossom_Test;
 
 class CmdBlossom
@@ -50,7 +48,5 @@ private:
     bool m_ignoreResult = false;
     bool m_trimOutput = false;
 };
-
-}
 
 #endif // CMD_BLOSSOM_H

--- a/src/processing/blossoms/special/exit_blossom.cpp
+++ b/src/processing/blossoms/special/exit_blossom.cpp
@@ -22,9 +22,6 @@
 
 #include "exit_blossom.h"
 
-namespace SakuraTree
-{
-
 ExitBlossom::ExitBlossom()
     : Blossom()
 {
@@ -78,6 +75,4 @@ void
 ExitBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/special/exit_blossom.h
+++ b/src/processing/blossoms/special/exit_blossom.h
@@ -25,8 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
 class ExitBlossom
         : public Blossom
 {
@@ -42,7 +40,5 @@ protected:
 private:
     int m_exitStatus = 0;
 };
-
-}
 
 #endif // EXIT_BLOSSOM_H

--- a/src/processing/blossoms/special/item_update_blossom.cpp
+++ b/src/processing/blossoms/special/item_update_blossom.cpp
@@ -23,9 +23,6 @@
 #include "item_update_blossom.h"
 #include <processing/common/item_methods.h>
 
-namespace SakuraTree
-{
-
 ItemUpdateBlossom::ItemUpdateBlossom()
     : Blossom()
 {
@@ -77,6 +74,4 @@ void
 ItemUpdateBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/special/item_update_blossom.h
+++ b/src/processing/blossoms/special/item_update_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class ItemUpdateBlossom
         : public Blossom
 {
@@ -42,7 +39,5 @@ protected:
     void postCheck(BlossomItem &blossomItem);
     void closeBlossom(BlossomItem &blossomItem);
 };
-
-}
 
 #endif // ITEM_UPDATE_BLOSSOM_H

--- a/src/processing/blossoms/special/print_blossom.cpp
+++ b/src/processing/blossoms/special/print_blossom.cpp
@@ -24,9 +24,6 @@
 #include <libKitsunemimiCommon/common_items/table_item.h>
 #include <libKitsunemimiPersistence/files/text_file.h>
 
-namespace SakuraTree
-{
-
 PrintBlossom::PrintBlossom()
     : Blossom()
 {
@@ -90,6 +87,4 @@ void
 PrintBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/special/print_blossom.h
+++ b/src/processing/blossoms/special/print_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class PrintBlossom
         : public Blossom
 {
@@ -42,7 +39,5 @@ protected:
     void postCheck(BlossomItem &blossomItem);
     void closeBlossom(BlossomItem &blossomItem);
 };
-
-}
 
 #endif // PRINT_BLOSSOM_H

--- a/src/processing/blossoms/ssh/ssh_cmd_blossom.cpp
+++ b/src/processing/blossoms/ssh/ssh_cmd_blossom.cpp
@@ -24,9 +24,6 @@
 
 #include <libKitsunemimiCommon/common_methods/string_methods.h>
 
-namespace SakuraTree
-{
-
 SshCmdBlossom::SshCmdBlossom()
     : Blossom()
 {
@@ -113,6 +110,4 @@ void
 SshCmdBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/ssh/ssh_cmd_blossom.h
+++ b/src/processing/blossoms/ssh/ssh_cmd_blossom.h
@@ -26,9 +26,6 @@
 #include <processing/blossoms/blossom.h>
 #include <unistd.h>
 
-namespace SakuraTree
-{
-
 class SshCmdBlossom
         : public Blossom
 {
@@ -49,7 +46,5 @@ private:
     std::string m_port = "";
     std::string m_sshKey = "";
 };
-
-}
 
 #endif // SSH_BLOSSOM_H

--- a/src/processing/blossoms/ssh/ssh_cmd_create_file_blossom.cpp
+++ b/src/processing/blossoms/ssh/ssh_cmd_create_file_blossom.cpp
@@ -24,9 +24,6 @@
 
 #include <libKitsunemimiCommon/common_methods/string_methods.h>
 
-namespace SakuraTree
-{
-
 SshCmdCreateFileBlossom::SshCmdCreateFileBlossom()
     : Blossom()
 {
@@ -141,6 +138,4 @@ void
 SshCmdCreateFileBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/ssh/ssh_cmd_create_file_blossom.h
+++ b/src/processing/blossoms/ssh/ssh_cmd_create_file_blossom.h
@@ -26,9 +26,6 @@
 #include <processing/blossoms/blossom.h>
 #include <unistd.h>
 
-namespace SakuraTree
-{
-
 class SshCmdCreateFileBlossom
         : public Blossom
 {
@@ -50,7 +47,5 @@ private:
     std::string m_filePath = "";
     std::string m_fileContent = "";
 };
-
-}
 
 #endif // SSH_CREATE_PATH_BLOSSOM_H

--- a/src/processing/blossoms/ssh/ssh_scp_blossom.cpp
+++ b/src/processing/blossoms/ssh/ssh_scp_blossom.cpp
@@ -24,9 +24,6 @@
 
 #include <libKitsunemimiCommon/common_methods/string_methods.h>
 
-namespace SakuraTree
-{
-
 SshScpBlossom::SshScpBlossom()
     : Blossom()
 {
@@ -110,6 +107,4 @@ void
 SshScpBlossom::closeBlossom(BlossomItem &blossomItem)
 {
     blossomItem.success = true;
-}
-
 }

--- a/src/processing/blossoms/ssh/ssh_scp_blossom.h
+++ b/src/processing/blossoms/ssh/ssh_scp_blossom.h
@@ -25,9 +25,6 @@
 
 #include <processing/blossoms/blossom.h>
 
-namespace SakuraTree
-{
-
 class SshScpBlossom
         : public Blossom
 {
@@ -49,7 +46,5 @@ private:
     std::string m_sourcePath = "";
     std::string m_targetPath = "";
 };
-
-}
 
 #endif // SCP_BLOSSOM_H

--- a/src/processing/common/item_methods.cpp
+++ b/src/processing/common/item_methods.cpp
@@ -31,9 +31,6 @@
 
 using Kitsunemimi::Jinja2::Jinja2Converter;
 
-namespace SakuraTree
-{
-
 /**
  * @brief process a value-item by handling its function-calls
  *
@@ -707,6 +704,4 @@ createError(const std::string &errorLocation,
     errorOutput.addRow(std::vector<std::string>{"error-message", errorMessage});
 
     return errorOutput.toString(200);
-}
-
 }

--- a/src/processing/common/item_methods.h
+++ b/src/processing/common/item_methods.h
@@ -33,8 +33,7 @@ class Jinja2Converter;
 }
 
 using Kitsunemimi::DataMap;
-namespace SakuraTree
-{
+
 
 bool getProcessedItem(ValueItem &valueItem,
                       DataMap &insertValues,
@@ -90,7 +89,5 @@ const std::string createError(const std::string &errorLocation,
                               const std::string &blossomGroupType = "",
                               const std::string &blossomName = "",
                               const std::string &blossomFilePath = "");
-
-}
 
 #endif // COMMON_METHODS_H

--- a/src/processing/sakura_thread.cpp
+++ b/src/processing/sakura_thread.cpp
@@ -34,9 +34,6 @@
 #include <libKitsunemimiPersistence/logger/logger.h>
 #include <libKitsunemimiPersistence/files/file_methods.h>
 
-namespace SakuraTree
-{
-
 /**
  * @brief constructor
  *
@@ -948,6 +945,4 @@ SakuraThread::runSubtreeCall(SakuraItem* newSubtree,
     overrideItems(m_parentValues, newSubtree->values);
 
     return true;
-}
-
 }

--- a/src/processing/sakura_thread.h
+++ b/src/processing/sakura_thread.h
@@ -29,9 +29,6 @@
 
 using namespace Kitsunemimi;
 
-namespace SakuraTree
-{
-
 class SakuraThread
         : public Kitsunemimi::Thread
 {
@@ -90,7 +87,5 @@ private:
                         std::string &errorMessage);
 
 };
-
-}
 
 #endif // SAKURA_THREAD_H

--- a/src/processing/sakura_tree_callbacks.h
+++ b/src/processing/sakura_tree_callbacks.h
@@ -30,9 +30,6 @@
 #include <libKitsunemimiCommon/buffer/data_buffer.h>
 #include <libKitsunemimiPersistence/logger/logger.h>
 
-namespace SakuraTree
-{
-
 enum objectType
 {
     UNDEFINED_OBJECT_TYPE = 0,
@@ -124,8 +121,6 @@ void sessionCallback(void* ,
                      const std::string)
 {
     //SakuraRoot* rootClass = static_cast<SakuraRoot*>(target);
-}
-
 }
 
 #endif // SAKURA_TREE_CALLBACKS_H

--- a/src/processing/subtree_queue.cpp
+++ b/src/processing/subtree_queue.cpp
@@ -22,9 +22,6 @@
 
 #include "subtree_queue.h"
 
-namespace SakuraTree
-{
-
 /**
  * @brief constructor
  */
@@ -62,6 +59,4 @@ SubtreeQueue::getSubtreeObject()
     m_lock.unlock();
 
     return subtree;
-}
-
 }

--- a/src/processing/subtree_queue.h
+++ b/src/processing/subtree_queue.h
@@ -26,9 +26,6 @@
 #include <common.h>
 #include <libKitsunemimiProjectNetwork/session.h>
 
-namespace SakuraTree
-{
-
 class SubtreeQueue
 {
 public:
@@ -119,7 +116,5 @@ private:
     std::queue<SubtreeObject*> m_queue;
 
 };
-
-}
 
 #endif // SUBTREE_QUEUE_H

--- a/src/processing/thread_pool.cpp
+++ b/src/processing/thread_pool.cpp
@@ -23,9 +23,6 @@
 #include "thread_pool.h"
 #include <processing/sakura_thread.h>
 
-namespace SakuraTree
-{
-
 /**
  * @brief constructor
  *
@@ -62,6 +59,4 @@ ThreadPool::clearChildThreads()
         delete childThread;
     }
     m_childThreads.clear();
-}
-
 }

--- a/src/processing/thread_pool.h
+++ b/src/processing/thread_pool.h
@@ -28,8 +28,6 @@
 #include <sakura_root.h>
 #include <processing/subtree_queue.h>
 
-namespace SakuraTree
-{
 class SakuraThread;
 
 class ThreadPool
@@ -45,7 +43,5 @@ private:
 
     std::vector<SakuraThread*> m_childThreads;
 };
-
-}
 
 #endif // THREAD_POOL_H

--- a/src/processing/validator.cpp
+++ b/src/processing/validator.cpp
@@ -26,9 +26,6 @@
 #include <processing/blossoms/blossom.h>
 #include <sakura_root.h>
 
-namespace SakuraTree
-{
-
 /**
  * @brief check if all values are set inside a blossom-item
  *
@@ -298,6 +295,4 @@ checkAllItems(const SakuraGarden &garden, std::string &errorMessage)
     }
 
     return true;
-}
-
 }

--- a/src/processing/validator.h
+++ b/src/processing/validator.h
@@ -25,9 +25,6 @@
 
 #include <common.h>
 
-namespace SakuraTree
-{
-
 bool checkOutput(BlossomItem &blossomItem,
                  const bool hasOutput,
                  std::string &errorMessage);
@@ -44,7 +41,5 @@ bool checkSakuraItem(SakuraItem* sakuraItem,
 
 bool checkAllItems(const SakuraGarden &garden,
                    std::string &errorMessage);
-
-}
 
 #endif // VALIDATOR_H

--- a/src/sakura_root.cpp
+++ b/src/sakura_root.cpp
@@ -43,9 +43,6 @@
 
 #include <sakura_provisioning_subtree.h>
 
-namespace SakuraTree
-{
-
 SakuraRoot* SakuraRoot::m_root = nullptr;
 std::string SakuraRoot::m_executablePath = "";
 std::string SakuraRoot::m_serverAddress = "127.0.0.1";
@@ -109,7 +106,7 @@ SakuraRoot::startProcess(const std::string &configFilePath)
     }
 
     // load config definition
-    SakuraTree::registerConfigs();
+    registerConfigs();
 
     const bool debug = GET_BOOL_CONFIG("DEFAULT", "debug", success);
     Kitsunemimi::Persistence::initFileLogger("/tmp/", "SakuraTree_log", debug);
@@ -384,6 +381,4 @@ SakuraRoot::loadPredefinedSubtrees(std::string &errorMessage)
     }
 
     return true;
-}
-
 }

--- a/src/sakura_root.h
+++ b/src/sakura_root.h
@@ -42,8 +42,6 @@ class Session;
 
 using Kitsunemimi::Jinja2::Jinja2Converter;
 
-namespace SakuraTree
-{
 class SakuraThread;
 class ThreadPool;
 
@@ -73,7 +71,7 @@ public:
     void printOutput(const std::string &output);
 
     // static values
-    static SakuraTree::SakuraRoot* m_root;
+    static SakuraRoot* m_root;
     static std::string m_executablePath;
     static std::string m_serverAddress;
     static uint16_t m_serverPort;
@@ -100,7 +98,5 @@ private:
                               std::string &errorMessage);
     bool loadPredefinedSubtrees(std::string &errorMessage);
 };
-
-}
 
 #endif // SAKURA_ROOT_H

--- a/tests/main_tests.cpp
+++ b/tests/main_tests.cpp
@@ -40,18 +40,18 @@
 int
 main(int argc, char *argv[])
 {
-    SakuraTree::ValueItemsFunctions_Test();
-    SakuraTree::ItemMethods_Test();
-    //SakuraTree::PathChmodBlossom_Test();
-    //SakuraTree::PathChownBlossom_Test();
-    SakuraTree::PathCopyBlossom_Test();
-    SakuraTree::PathDeleteBlossom_Test();
-    SakuraTree::PathRenameBlossom_Test();
-    SakuraTree::TemplateCreateBlossom_Test();
-    SakuraTree::CmdBlossom_Test();
-    SakuraTree::TextReadBlossom_Test();
-    SakuraTree::TextWriteBlossom_Test();
-    SakuraTree::TextAppendBlossom_Test();
-    SakuraTree::TextReplaceBlossom_Test();
+    ValueItemsFunctions_Test();
+    ItemMethods_Test();
+    //PathChmodBlossom_Test();
+    //PathChownBlossom_Test();
+    PathCopyBlossom_Test();
+    PathDeleteBlossom_Test();
+    PathRenameBlossom_Test();
+    TemplateCreateBlossom_Test();
+    CmdBlossom_Test();
+    TextReadBlossom_Test();
+    TextWriteBlossom_Test();
+    TextAppendBlossom_Test();
+    TextReplaceBlossom_Test();
     return 0;
 }

--- a/tests/processing/blossoms/files/common_files/path_chmod_blossom_test.cpp
+++ b/tests/processing/blossoms/files/common_files/path_chmod_blossom_test.cpp
@@ -22,9 +22,6 @@
 
 #include "path_chmod_blossom_test.h"
 
-namespace SakuraTree
-{
-
 PathChmodBlossom_Test::PathChmodBlossom_Test()
     : Kitsunemimi::CompareTestHelper("PathChmodBlossom_Test")
 {
@@ -77,7 +74,5 @@ PathChmodBlossom_Test::postCheck_test()
 void
 PathChmodBlossom_Test::closeTask_test()
 {
-
-}
 
 }

--- a/tests/processing/blossoms/files/common_files/path_chmod_blossom_test.h
+++ b/tests/processing/blossoms/files/common_files/path_chmod_blossom_test.h
@@ -26,9 +26,6 @@
 #include <common.h>
 #include <libKitsunemimiCommon/test_helper/compare_test_helper.h>
 
-namespace SakuraTree
-{
-
 class PathChmodBlossom_Test
         : public Kitsunemimi::CompareTestHelper
 {
@@ -42,7 +39,5 @@ private:
     void postCheck_test();
     void closeTask_test();
 };
-
-}
 
 #endif // PATH_CHMOD_BLOSSOM_TEST_H

--- a/tests/processing/blossoms/files/common_files/path_chown_blossom_test.cpp
+++ b/tests/processing/blossoms/files/common_files/path_chown_blossom_test.cpp
@@ -22,9 +22,6 @@
 
 #include "path_chown_blossom_test.h"
 
-namespace SakuraTree
-{
-
 PathChownBlossom_Test::PathChownBlossom_Test()
     : Kitsunemimi::CompareTestHelper("PathChownBlossom_Test")
 {
@@ -77,7 +74,5 @@ PathChownBlossom_Test::postCheck_test()
 void
 PathChownBlossom_Test::closeTask_test()
 {
-
-}
 
 }

--- a/tests/processing/blossoms/files/common_files/path_chown_blossom_test.h
+++ b/tests/processing/blossoms/files/common_files/path_chown_blossom_test.h
@@ -26,9 +26,6 @@
 #include <common.h>
 #include <libKitsunemimiCommon/test_helper/compare_test_helper.h>
 
-namespace SakuraTree
-{
-
 class PathChownBlossom_Test
         : public Kitsunemimi::CompareTestHelper
 {
@@ -42,7 +39,5 @@ private:
     void postCheck_test();
     void closeTask_test();
 };
-
-}
 
 #endif // PATH_CHOWN_BLOSSOM_TEST_H

--- a/tests/processing/blossoms/files/common_files/path_copy_blossom_test.cpp
+++ b/tests/processing/blossoms/files/common_files/path_copy_blossom_test.cpp
@@ -23,9 +23,6 @@
 #include "path_copy_blossom_test.h"
 #include <processing/blossoms/files/common_files/path_copy_blossom.h>
 
-namespace SakuraTree
-{
-
 PathCopyBlossom_Test::PathCopyBlossom_Test()
     : Kitsunemimi::CompareTestHelper("PathCopyBlossom_Test")
 {
@@ -162,6 +159,4 @@ PathCopyBlossom_Test::closeTask_test()
     fakeCopyBlossom.initBlossom(fakeItem);
     fakeCopyBlossom.closeBlossom(fakeItem);
     TEST_EQUAL(fakeItem.success, true);
-}
-
 }

--- a/tests/processing/blossoms/files/common_files/path_copy_blossom_test.h
+++ b/tests/processing/blossoms/files/common_files/path_copy_blossom_test.h
@@ -26,9 +26,6 @@
 #include <common.h>
 #include <libKitsunemimiCommon/test_helper/compare_test_helper.h>
 
-namespace SakuraTree
-{
-
 class PathCopyBlossom_Test
         : public Kitsunemimi::CompareTestHelper
 {
@@ -46,7 +43,5 @@ private:
     std::string m_sourceFile = "";
     std::string m_destinationFile = "";
 };
-
-}
 
 #endif // PATH_COPY_BLOSSOM_TEST_H

--- a/tests/processing/blossoms/files/common_files/path_delete_blossom_test.cpp
+++ b/tests/processing/blossoms/files/common_files/path_delete_blossom_test.cpp
@@ -23,9 +23,6 @@
 #include "path_delete_blossom_test.h"
 #include <processing/blossoms/files/common_files/path_delete_blossom.h>
 
-namespace SakuraTree
-{
-
 PathDeleteBlossom_Test::PathDeleteBlossom_Test()
     : Kitsunemimi::CompareTestHelper("PathDeleteBlossom_Test")
 {
@@ -146,6 +143,4 @@ PathDeleteBlossom_Test::closeTask_test()
     fakeDeleteBlossom.initBlossom(fakeItem);
     fakeDeleteBlossom.closeBlossom(fakeItem);
     TEST_EQUAL(fakeItem.success, true);
-}
-
 }

--- a/tests/processing/blossoms/files/common_files/path_delete_blossom_test.h
+++ b/tests/processing/blossoms/files/common_files/path_delete_blossom_test.h
@@ -26,9 +26,6 @@
 #include <common.h>
 #include <libKitsunemimiCommon/test_helper/compare_test_helper.h>
 
-namespace SakuraTree
-{
-
 class PathDeleteBlossom_Test
         : public Kitsunemimi::CompareTestHelper
 {
@@ -45,7 +42,5 @@ private:
 
     std::string m_path = "";
 };
-
-}
 
 #endif // PATH_DELETE_BLOSSOM_TEST_H

--- a/tests/processing/blossoms/files/common_files/path_rename_blossom_test.cpp
+++ b/tests/processing/blossoms/files/common_files/path_rename_blossom_test.cpp
@@ -23,9 +23,6 @@
 #include "path_rename_blossom_test.h"
 #include <processing/blossoms/files/common_files/path_rename_blossom.h>
 
-namespace SakuraTree
-{
-
 PathRenameBlossom_Test::PathRenameBlossom_Test()
     : Kitsunemimi::CompareTestHelper("PathRenameBlossom_Test")
 {
@@ -174,6 +171,4 @@ PathRenameBlossom_Test::closeTask_test()
     fakeRenameBlossom.initBlossom(fakeItem);
     fakeRenameBlossom.closeBlossom(fakeItem);
     TEST_EQUAL(fakeItem.success, true);
-}
-
 }

--- a/tests/processing/blossoms/files/common_files/path_rename_blossom_test.h
+++ b/tests/processing/blossoms/files/common_files/path_rename_blossom_test.h
@@ -26,9 +26,6 @@
 #include <common.h>
 #include <libKitsunemimiCommon/test_helper/compare_test_helper.h>
 
-namespace SakuraTree
-{
-
 class PathRenameBlossom_Test
         : public Kitsunemimi::CompareTestHelper
 {
@@ -47,7 +44,5 @@ private:
     std::string m_destinationFileName = "";
     std::string m_destinationFile = "";
 };
-
-}
 
 #endif // PATH_RENAME_BLOSSOM_TEST_H

--- a/tests/processing/blossoms/files/template_files/template_create_blossom_test.cpp
+++ b/tests/processing/blossoms/files/template_files/template_create_blossom_test.cpp
@@ -24,9 +24,6 @@
 #include <processing/blossoms/files/template_files/template_create_file_blossom.h>
 #include <libKitsunemimiPersistence/files/text_file.h>
 
-namespace SakuraTree
-{
-
 TemplateCreateBlossom_Test::TemplateCreateBlossom_Test()
     : Kitsunemimi::CompareTestHelper("TemplateCreateBlossom_Test")
 {
@@ -186,6 +183,4 @@ TemplateCreateBlossom_Test::closeTask_test()
     fakeCopyBlossom.initBlossom(fakeItem);
     fakeCopyBlossom.closeBlossom(fakeItem);
     TEST_EQUAL(fakeItem.success, true);
-}
-
 }

--- a/tests/processing/blossoms/files/template_files/template_create_blossom_test.h
+++ b/tests/processing/blossoms/files/template_files/template_create_blossom_test.h
@@ -27,9 +27,6 @@
 #include <libKitsunemimiCommon/test_helper/compare_test_helper.h>
 #include <sakura_root.h>
 
-namespace SakuraTree
-{
-
 class TemplateCreateBlossom_Test
         : public Kitsunemimi::CompareTestHelper
 {
@@ -53,7 +50,5 @@ private:
 
     SakuraRoot* m_root = nullptr;
 };
-
-}
 
 #endif // TEMPLATE_CREATE_BLOSSOM_TEST_H

--- a/tests/processing/blossoms/files/text_files/text_append_blossom_test.cpp
+++ b/tests/processing/blossoms/files/text_files/text_append_blossom_test.cpp
@@ -24,9 +24,6 @@
 #include <processing/blossoms/files/text_files/text_append_blossom.h>
 #include <libKitsunemimiPersistence/files/text_file.h>
 
-namespace SakuraTree
-{
-
 TextAppendBlossom_Test::TextAppendBlossom_Test()
     : Kitsunemimi::CompareTestHelper("TextAppendBlossom_Test")
 {
@@ -157,6 +154,4 @@ TextAppendBlossom_Test::closeTask_test()
     appendBlossom.initBlossom(blossomItem);
     appendBlossom.closeBlossom(blossomItem);
     TEST_EQUAL(blossomItem.success, true);
-}
-
 }

--- a/tests/processing/blossoms/files/text_files/text_append_blossom_test.h
+++ b/tests/processing/blossoms/files/text_files/text_append_blossom_test.h
@@ -26,9 +26,6 @@
 #include <common.h>
 #include <libKitsunemimiCommon/test_helper/compare_test_helper.h>
 
-namespace SakuraTree
-{
-
 class TextAppendBlossom_Test
         : public Kitsunemimi::CompareTestHelper
 {
@@ -47,7 +44,5 @@ private:
     std::string m_text = "";
     std::string m_newText = "";
 };
-
-}
 
 #endif // TEXT_APPEND_BLOSSOM_TEST_H

--- a/tests/processing/blossoms/files/text_files/text_read_blossom_test.cpp
+++ b/tests/processing/blossoms/files/text_files/text_read_blossom_test.cpp
@@ -24,9 +24,6 @@
 #include <processing/blossoms/files/text_files/text_read_blossom.h>
 #include <libKitsunemimiPersistence/files/text_file.h>
 
-namespace SakuraTree
-{
-
 TextReadBlossom_Test::TextReadBlossom_Test()
     : Kitsunemimi::CompareTestHelper("TextReadBlossom_Test")
 {
@@ -146,6 +143,4 @@ TextReadBlossom_Test::closeTask_test()
     readBlossom.initBlossom(blossomItem);
     readBlossom.closeBlossom(blossomItem);
     TEST_EQUAL(blossomItem.success, true);
-}
-
 }

--- a/tests/processing/blossoms/files/text_files/text_read_blossom_test.h
+++ b/tests/processing/blossoms/files/text_files/text_read_blossom_test.h
@@ -26,9 +26,6 @@
 #include <common.h>
 #include <libKitsunemimiCommon/test_helper/compare_test_helper.h>
 
-namespace SakuraTree
-{
-
 class TextReadBlossom_Test
         : public Kitsunemimi::CompareTestHelper
 {
@@ -46,7 +43,5 @@ private:
     std::string m_path = "";
     std::string m_text = "";
 };
-
-}
 
 #endif // TEXT_READ_BLOSSOM_TEST_H

--- a/tests/processing/blossoms/files/text_files/text_replace_blossom_test.cpp
+++ b/tests/processing/blossoms/files/text_files/text_replace_blossom_test.cpp
@@ -24,9 +24,6 @@
 #include <processing/blossoms/files/text_files/text_replace_blossom.h>
 #include <libKitsunemimiPersistence/files/text_file.h>
 
-namespace SakuraTree
-{
-
 TextReplaceBlossom_Test::TextReplaceBlossom_Test()
     : Kitsunemimi::CompareTestHelper("TextReplaceBlossom_Test")
 {
@@ -166,6 +163,4 @@ TextReplaceBlossom_Test::closeTask_test()
     replaceBlossom.initBlossom(blossomItem);
     replaceBlossom.closeBlossom(blossomItem);
     TEST_EQUAL(blossomItem.success, true);
-}
-
 }

--- a/tests/processing/blossoms/files/text_files/text_replace_blossom_test.h
+++ b/tests/processing/blossoms/files/text_files/text_replace_blossom_test.h
@@ -26,9 +26,6 @@
 #include <common.h>
 #include <libKitsunemimiCommon/test_helper/compare_test_helper.h>
 
-namespace SakuraTree
-{
-
 class TextReplaceBlossom_Test
         : public Kitsunemimi::CompareTestHelper
 {
@@ -49,7 +46,5 @@ private:
     std::string m_oldText = "";
     std::string m_newText = "";
 };
-
-}
 
 #endif // TEXT_REPLACE_BLOSSOM_TEST_H

--- a/tests/processing/blossoms/files/text_files/text_write_blossom_test.cpp
+++ b/tests/processing/blossoms/files/text_files/text_write_blossom_test.cpp
@@ -24,9 +24,6 @@
 #include <processing/blossoms/files/text_files/text_write_blossom.h>
 #include <libKitsunemimiPersistence/files/text_file.h>
 
-namespace SakuraTree
-{
-
 TextWriteBlossom_Test::TextWriteBlossom_Test()
     : Kitsunemimi::CompareTestHelper("TextWriteBlossom_Test")
 {
@@ -144,6 +141,4 @@ TextWriteBlossom_Test::closeTask_test()
     writeBlossom.initBlossom(blossomItem);
     writeBlossom.closeBlossom(blossomItem);
     TEST_EQUAL(blossomItem.success, true);
-}
-
 }

--- a/tests/processing/blossoms/files/text_files/text_write_blossom_test.h
+++ b/tests/processing/blossoms/files/text_files/text_write_blossom_test.h
@@ -26,9 +26,6 @@
 #include <common.h>
 #include <libKitsunemimiCommon/test_helper/compare_test_helper.h>
 
-namespace SakuraTree
-{
-
 class TextWriteBlossom_Test
         : public Kitsunemimi::CompareTestHelper
 {
@@ -46,7 +43,5 @@ private:
     std::string m_path = "";
     std::string m_text = "";
 };
-
-}
 
 #endif // TEXT_WRITE_BLOSSOM_TEST_H

--- a/tests/processing/blossoms/special/cmd_blossom_test.cpp
+++ b/tests/processing/blossoms/special/cmd_blossom_test.cpp
@@ -24,9 +24,6 @@
 #include <processing/blossoms/special/cmd_blossom.h>
 #include <libKitsunemimiPersistence/files/file_methods.h>
 
-namespace SakuraTree
-{
-
 CmdBlossom_Test::CmdBlossom_Test()
     : Kitsunemimi::CompareTestHelper("CmdBlossom_Test")
 {
@@ -134,6 +131,4 @@ CmdBlossom_Test::closeTask_test()
     fakeCmdBlossom.initBlossom(fakeItem);
     fakeCmdBlossom.closeBlossom(fakeItem);
     TEST_EQUAL(fakeItem.success, true);
-}
-
 }

--- a/tests/processing/blossoms/special/cmd_blossom_test.h
+++ b/tests/processing/blossoms/special/cmd_blossom_test.h
@@ -26,9 +26,6 @@
 #include <common.h>
 #include <libKitsunemimiCommon/test_helper/compare_test_helper.h>
 
-namespace SakuraTree
-{
-
 class CmdBlossom_Test
         : public Kitsunemimi::CompareTestHelper
 {
@@ -47,7 +44,5 @@ private:
     std::string m_filePath = "";
     std::string m_command = "";
 };
-
-}
 
 #endif // CMD_BLOSSOM_TEST_H

--- a/tests/processing/common/functions_test.cpp
+++ b/tests/processing/common/functions_test.cpp
@@ -22,9 +22,6 @@
 
 #include "functions_test.h"
 
-namespace SakuraTree
-{
-
 /**
  * @brief constructor
  */
@@ -255,6 +252,4 @@ ValueItemsFunctions_Test::insertValue_test()
     // negative tests
     result = insertValue(nullptr, new DataValue("12345"), new DataValue("12345"), errorMessage);
     checkNullptr(result);
-}
-
 }

--- a/tests/processing/common/functions_test.h
+++ b/tests/processing/common/functions_test.h
@@ -27,8 +27,6 @@
 #include <libKitsunemimiCommon/test_helper/compare_test_helper.h>
 #include <processing/common/value_item_functions.h>
 
-namespace SakuraTree
-{
 class ValueItemsFunctions_Test
         : public Kitsunemimi::CompareTestHelper
 {
@@ -45,7 +43,5 @@ private:
 
     void checkNullptr(DataItem *value);
 };
-
-}
 
 #endif // VALUE_ITEMS_FUNCTIONS_TEST_H

--- a/tests/processing/common/item_methods_test.cpp
+++ b/tests/processing/common/item_methods_test.cpp
@@ -25,9 +25,6 @@
 #include <sakura_root.h>
 #include <libKitsunemimiJinja2/jinja2_converter.h>
 
-namespace SakuraTree
-{
-
 /**
  * @brief constructor
  */
@@ -115,6 +112,4 @@ void
 ItemMethods_Test::cleanupTestCase()
 {
     delete m_root;
-}
-
 }

--- a/tests/processing/common/item_methods_test.h
+++ b/tests/processing/common/item_methods_test.h
@@ -27,8 +27,6 @@
 #include <libKitsunemimiCommon/test_helper/compare_test_helper.h>
 #include <processing/common/item_methods.h>
 
-namespace SakuraTree
-{
 class SakuraRoot;
 
 class ItemMethods_Test
@@ -46,7 +44,5 @@ private:
 
     SakuraRoot* m_root = nullptr;
 };
-
-}
 
 #endif // COMMON_METHODS_TEST_H


### PR DESCRIPTION
## Description

remove SakuraTree-namespace from all files, because its not necessary

## Related Issues

- #178 

## How it was tested?

- compiled